### PR TITLE
Add late-initialization configuration use-cases

### DIFF
--- a/docs/adding-resources.md
+++ b/docs/adding-resources.md
@@ -408,6 +408,20 @@ As an example if you would like to ignore `DelegationParameters.Name`
 fields during late-initialization, the relative name to be used is:
 `Delegation.Name`.
 
+In most cases, custom late-initialization configuration will not be necessary. However,
+after generating a new managed resource and observing its behaviour (at runtime),
+it may turn out that late-initialization behaviour needs customization. For certain
+resources like the `provider-tf-azure`'s `PostgresqlServer` resource, we have
+observed that Terraform state contains values for mutually exclusive parameters, e.g.,
+for `PostgresqlServer`, both `StorageMb` and `StorageProfile[].StorageMb` get
+late-initialized. Upon next reconciliation, we generate values for both parameters in the
+Terraform configuration, and although they happen to have the same value, Terraform
+configuration validation requires them to be mutually exclusive. Currently, we observe
+this behaviour at runtime, and upon observing that the resource cannot transition to the
+`Ready` state and acquires the Terraform validation error message in its `status.conditions`,
+we do the `LateInitializer.IgnoreFields` custom configuration detailed above to skip
+one of the mutually exclusive fields during late-initialization.
+
 [comment]: <> (References)
 
 [Terrajet]: https://github.com/crossplane-contrib/terrajet


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Documentation update to discuss about the use-cases around custom late-initialization configurations, e.g., when you might need to customize late-initialization behavior of Terraformed resources. This part has been cherry-picked from: https://github.com/crossplane-contrib/provider-tf-azure/pull/82

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
