### PR TITLE
Marking passwords field of aws_elasticache_user as sensitive

### DIFF
--- a/apis/elasticache/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/elasticache/v1alpha2/zz_generated.deepcopy.go
@@ -1370,15 +1370,13 @@ func (in *UserParameters) DeepCopyInto(out *UserParameters) {
 		*out = new(bool)
 		**out = **in
 	}
-	if in.Passwords != nil {
-		in, out := &in.Passwords, &out.Passwords
-		*out = make([]*string, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(string)
-				**out = **in
-			}
+	if in.PasswordsSecretRef != nil {
+		in, out := &in.PasswordsSecretRef, &out.PasswordsSecretRef
+		*out = new([]v1.SecretKeySelector)
+		if **in != nil {
+			in, out := *in, *out
+			*out = make([]v1.SecretKeySelector, len(*in))
+			copy(*out, *in)
 		}
 	}
 	if in.Region != nil {

--- a/apis/elasticache/v1alpha2/zz_user_terraformed.go
+++ b/apis/elasticache/v1alpha2/zz_user_terraformed.go
@@ -32,7 +32,7 @@ func (mg *User) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this User
 func (tr *User) GetConnectionDetailsMapping() map[string]string {
-	return nil
+	return map[string]string{"passwords": "spec.forProvider.passwordsSecretRef"}
 }
 
 // GetObservation of this User

--- a/apis/elasticache/v1alpha2/zz_user_types.go
+++ b/apis/elasticache/v1alpha2/zz_user_types.go
@@ -46,7 +46,7 @@ type UserParameters struct {
 	NoPasswordRequired *bool `json:"noPasswordRequired,omitempty" tf:"no_password_required,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	Passwords []*string `json:"passwords,omitempty" tf:"passwords,omitempty"`
+	PasswordsSecretRef *[]v1.SecretKeySelector `json:"passwordsSecretRef,omitempty" tf:"-"`
 
 	// Region is the region you'd like your resource to be created in.
 	// +terrajet:crd:field:TFTag=-

--- a/config/elasticache/config.go
+++ b/config/elasticache/config.go
@@ -65,6 +65,9 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_elasticache_user", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
+		if s, ok := r.TerraformResource.Schema["passwords"]; ok {
+			s.Sensitive = true
+		}
 		r.ExternalName = config.ExternalName{
 			SetIdentifierArgumentFn: func(base map[string]interface{}, name string) {
 				base["user_id"] = name

--- a/examples/elasticache/user.yaml
+++ b/examples/elasticache/user.yaml
@@ -1,0 +1,20 @@
+apiVersion: elasticache.aws.jet.crossplane.io/v1alpha2
+kind: User
+metadata:
+  name: sample-user
+spec:
+  forProvider:
+    userName: "testUserName"
+    accessString: "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
+    engine: "REDIS"
+    region: us-west-1
+    passwordsSecretRef:
+      - name: user-passwords
+        namespace: crossplane-system
+        key: pwd-1
+      - name: user-passwords
+        namespace: crossplane-system
+        key: pwd-2
+  writeConnectionSecretToRef:
+    name: user-conn
+    namespace: default

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/crossplane/crossplane-runtime v0.15.1-0.20211004150827-579c1833b513
 	github.com/crossplane/crossplane-tools v0.0.0-20210916125540-071de511ae8e
 	github.com/crossplane/provider-aws v0.23.0
-	github.com/crossplane/terrajet v0.4.0-rc.0.0.20220128111246-e5aaa1790fe6
+	github.com/crossplane/terrajet v0.4.0-rc.0.0.20220221102850-391b75996abf
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210811232925-d6f99829ec3f

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,8 @@ github.com/crossplane/crossplane-tools v0.0.0-20210916125540-071de511ae8e h1:7UM
 github.com/crossplane/crossplane-tools v0.0.0-20210916125540-071de511ae8e/go.mod h1:3GzY5sP0PVePArghBh5K4fGzS/3kM0R/NAZn5s7LXqw=
 github.com/crossplane/provider-aws v0.23.0 h1:PK5SfgEYY4mu/BrP+AkH5jRG/B/XYF06E+k55NdX6f4=
 github.com/crossplane/provider-aws v0.23.0/go.mod h1:+seFgtg4gbUEhtdYPD7xqlNKkLncGcUFwU/nU2uOM8Y=
-github.com/crossplane/terrajet v0.4.0-rc.0.0.20220128111246-e5aaa1790fe6 h1:Msk6WqLQ+anlAjN8PFZun/XOJqAh0zC+PgmlyqqAkrw=
-github.com/crossplane/terrajet v0.4.0-rc.0.0.20220128111246-e5aaa1790fe6/go.mod h1:fFjGal+3iF/D3XaxuTHw0xNHO+UslVhxNkNZITDXz44=
+github.com/crossplane/terrajet v0.4.0-rc.0.0.20220221102850-391b75996abf h1:EqzVnRksna58jMiLZRCU3ZCvLK9IuMt+tOZ3RVEllQg=
+github.com/crossplane/terrajet v0.4.0-rc.0.0.20220221102850-391b75996abf/go.mod h1:hkFaUFClOfpeCtWahn3RxjyDEFIyP2qLDQVjOdHFHiQ=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=
 github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpTVGlwA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -455,8 +455,9 @@ github.com/hashicorp/terraform-exec v0.13.3/go.mod h1:SSg6lbUsVB3DmFyCPjBPklqf6E
 github.com/hashicorp/terraform-exec v0.14.0 h1:UQoUcxKTZZXhyyK68Cwn4mApT4mnFPmEXPiqaHL9r+w=
 github.com/hashicorp/terraform-exec v0.14.0/go.mod h1:qrAASDq28KZiMPDnQ02sFS9udcqEkRly002EA2izXTA=
 github.com/hashicorp/terraform-json v0.10.0/go.mod h1:3defM4kkMfttwiE7VakJDwCd4R+umhSQnvJwORXbprE=
-github.com/hashicorp/terraform-json v0.12.0 h1:8czPgEEWWPROStjkWPUnTQDXmpmZPlkQAwYYLETaTvw=
 github.com/hashicorp/terraform-json v0.12.0/go.mod h1:pmbq9o4EuL43db5+0ogX10Yofv1nozM+wskr/bGFJpI=
+github.com/hashicorp/terraform-json v0.13.0 h1:Li9L+lKD1FO5RVFRM1mMMIBDoUHslOniyEi5CM+FWGY=
+github.com/hashicorp/terraform-json v0.13.0/go.mod h1:y5OdLBCT+rxbwnpxZs9kGL7R9ExU76+cpdY8zHwoazk=
 github.com/hashicorp/terraform-plugin-go v0.3.0 h1:AJqYzP52JFYl9NABRI7smXI1pNjgR5Q/y2WyVJ/BOZA=
 github.com/hashicorp/terraform-plugin-go v0.3.0/go.mod h1:dFHsQMaTLpON2gWhVWT96fvtlc/MF1vSy3OdMhWBzdM=
 github.com/hashicorp/terraform-plugin-sdk v1.17.2 h1:V7DUR3yBWFrVB9z3ddpY7kiYVSsq4NYR67NiTs93NQo=
@@ -596,8 +597,8 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32 h1:yBQlHXLeUJL3TWVmzup5uT3wG5FLxhiTAiTsmNVocys=
-github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32/go.mod h1:SAAdeMEiFXR8LcHffvIdiLI1w243DCH2DuHq7UrA5YQ=
+github.com/muvaf/typewriter v0.0.0-20220131201631-921e94e8e8d7 h1:CxRHKnh1YJXgNKxcos9rrKL6AcmOl1AS/fygmxFDzh4=
+github.com/muvaf/typewriter v0.0.0-20220131201631-921e94e8e8d7/go.mod h1:SAAdeMEiFXR8LcHffvIdiLI1w243DCH2DuHq7UrA5YQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
@@ -749,8 +750,9 @@ github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLE
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.8.2/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
-github.com/zclconf/go-cty v1.8.4 h1:pwhhz5P+Fjxse7S7UriBrMu6AUJSZM5pKqGem1PjGAs=
 github.com/zclconf/go-cty v1.8.4/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zclconf/go-cty v1.9.1 h1:viqrgQwFl5UpSxc046qblj78wZXVDFnSOufaOTER+cc=
+github.com/zclconf/go-cty v1.9.1/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
 github.com/zclconf/go-cty-yaml v1.0.2/go.mod h1:IP3Ylp0wQpYm50IHK8OZWKMu6sPJIUgKa8XhiVHura0=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/package/crds/elasticache.aws.jet.crossplane.io_users.yaml
+++ b/package/crds/elasticache.aws.jet.crossplane.io_users.yaml
@@ -70,9 +70,25 @@ spec:
                     type: string
                   noPasswordRequired:
                     type: boolean
-                  passwords:
+                  passwordsSecretRef:
                     items:
-                      type: string
+                      description: A SecretKeySelector is a reference to a secret
+                        key in an arbitrary namespace.
+                      properties:
+                        key:
+                          description: The key to select.
+                          type: string
+                        name:
+                          description: Name of the secret.
+                          type: string
+                        namespace:
+                          description: Namespace of the secret.
+                          type: string
+                      required:
+                      - key
+                      - name
+                      - namespace
+                      type: object
                     type: array
                   region:
                     description: Region is the region you'd like your resource to


### PR DESCRIPTION
### Description of your changes

Depends on https://github.com/crossplane/terrajet/issues/100

This PR depends on the following one -> https://github.com/crossplane/terrajet/pull/197
Until merge the dependent PR, a temporary replace command was added to go.mod:

https://github.com/sergenyalcin/provider-jet-aws/blob/ae8fb3a002c0e24f868d0d608fa365ef42d6da7e/go.mod#L26

This PR marks the passwords field of aws_elasticache_user as sensitive. Now, this field is not sensitive and the passwords are put to the spec directly. Because for []string and []*string types, there is not support as sensitive fields. The dependent PR will provide this support. After merging the dependent PR in terrajet, this PR can be merged.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Generation of the resource was successfully completed. The `PasswordsSecretRef` field was generated as 
`*[]v1.SecretKeySelector`

- I created the following manifest:

```
apiVersion: elasticache.aws.jet.crossplane.io/v1alpha1
kind: User
metadata:
  name: sample-user
spec:
  forProvider:
    userName: "testUserName"
    accessString: "on ~app::* -@all +@read +@hash +@bitmap +@geo -setbit -bitfield -hset -hsetnx -hmset -hincrby -hincrbyfloat -hdel -bitop -geoadd -georadius -georadiusbymember"
    engine: "REDIS"
    region: us-west-1
    passwordsSecretRef:
      - name: test-slice-1
        namespace: crossplane-system
        key: pwd
      - name: test-slice-2
        namespace: crossplane-system
        key: pwd
  writeConnectionSecretToRef:
    name: test-conn
    namespace: default
```

- The external resource was successfully created and the connection secret had the correct values.

[contribution process]: https://git.io/fj2m9
