### PR TITLE
Apply tagging convention

### DIFF
--- a/config/common/common.go
+++ b/config/common/common.go
@@ -33,6 +33,9 @@ const (
 	// VersionV1Alpha2 is used as minimum version for all manually configured
 	// resources.
 	VersionV1Alpha2 = "v1alpha2"
+
+	// ExternalTagsFieldName is used as field name to set external resource tags.
+	ExternalTagsFieldName = "Tags"
 )
 
 // ARNExtractor extracts ARN of the resources from "status.atProvider.arn" which

--- a/config/overrides.go
+++ b/config/overrides.go
@@ -440,3 +440,16 @@ func KnownReferencers() tjconfig.ResourceOption { //nolint:gocyclo
 		}
 	}
 }
+
+// AddExternalTagsField adds ExternalTagsFieldName configuration for resources that have tags field.
+func AddExternalTagsField() tjconfig.ResourceOption {
+	return func(r *tjconfig.Resource) {
+		if s, ok := r.TerraformResource.Schema["tags"]; ok {
+			if s.Type == schema.TypeMap {
+				r.InitializerFns = []tjconfig.NewInitializerFn{
+					tjconfig.TagInitializer,
+				}
+			}
+		}
+	}
+}

--- a/config/overrides.go
+++ b/config/overrides.go
@@ -444,12 +444,8 @@ func KnownReferencers() tjconfig.ResourceOption { //nolint:gocyclo
 // AddExternalTagsField adds ExternalTagsFieldName configuration for resources that have tags field.
 func AddExternalTagsField() tjconfig.ResourceOption {
 	return func(r *tjconfig.Resource) {
-		if s, ok := r.TerraformResource.Schema["tags"]; ok {
-			if s.Type == schema.TypeMap {
-				r.InitializerFns = []tjconfig.NewInitializerFn{
-					tjconfig.TagInitializer,
-				}
-			}
+		if s, ok := r.TerraformResource.Schema["tags"]; ok && s.Type == schema.TypeMap {
+			r.InitializerFns = append(r.InitializerFns, tjconfig.TagInitializer)
 		}
 	}
 }

--- a/config/provider.go
+++ b/config/provider.go
@@ -161,6 +161,7 @@ func GetProvider(tfProvider *schema.Provider) *tjconfig.Provider {
 			IdentifierAssignedByAWS(),
 			NamePrefixRemoval(),
 			KnownReferencers(),
+			AddExternalTagsField(),
 		)),
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/crossplane/crossplane-runtime v0.15.1-0.20211004150827-579c1833b513
 	github.com/crossplane/crossplane-tools v0.0.0-20210916125540-071de511ae8e
 	github.com/crossplane/provider-aws v0.19.0
-	github.com/crossplane/terrajet v0.3.1
+	github.com/crossplane/terrajet v0.4.0-rc.0.0.20220128111246-e5aaa1790fe6
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/terraform-providers/terraform-provider-aws v1.60.1-0.20210811232925-d6f99829ec3f
@@ -20,5 +20,3 @@ require (
 )
 
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/gdavison/terraform-plugin-sdk/v2 v2.0.2-0.20210714181518-b5a3dc95a675
-
-replace github.com/crossplane/terrajet => github.com/sergenyalcin/terrajet v0.1.1-0.20220127142712-72b516c4485a

--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,5 @@ require (
 )
 
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/gdavison/terraform-plugin-sdk/v2 v2.0.2-0.20210714181518-b5a3dc95a675
+
+replace github.com/crossplane/terrajet => github.com/sergenyalcin/terrajet v0.1.1-0.20220127142712-72b516c4485a

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,8 @@ github.com/crossplane/crossplane-tools v0.0.0-20210916125540-071de511ae8e h1:7UM
 github.com/crossplane/crossplane-tools v0.0.0-20210916125540-071de511ae8e/go.mod h1:3GzY5sP0PVePArghBh5K4fGzS/3kM0R/NAZn5s7LXqw=
 github.com/crossplane/provider-aws v0.19.0 h1:pfjxtuj0ZEllzBnyA7X2MgM62EqSwKCdBwIHPsbPEBM=
 github.com/crossplane/provider-aws v0.19.0/go.mod h1:ntcIkyfgz/y+WgfBmse05S6RnCxK4cmhhtI8a7IzySs=
+github.com/crossplane/terrajet v0.4.0-rc.0.0.20220128111246-e5aaa1790fe6 h1:Msk6WqLQ+anlAjN8PFZun/XOJqAh0zC+PgmlyqqAkrw=
+github.com/crossplane/terrajet v0.4.0-rc.0.0.20220128111246-e5aaa1790fe6/go.mod h1:fFjGal+3iF/D3XaxuTHw0xNHO+UslVhxNkNZITDXz44=
 github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=
 github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpTVGlwA=
@@ -744,8 +746,6 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
-github.com/sergenyalcin/terrajet v0.1.1-0.20220127142712-72b516c4485a h1:IKr7Sk3ZPYelILT33PJaZP3rXD+RVTgW2wMbkeflJvU=
-github.com/sergenyalcin/terrajet v0.1.1-0.20220127142712-72b516c4485a/go.mod h1:fFjGal+3iF/D3XaxuTHw0xNHO+UslVhxNkNZITDXz44=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,6 @@ github.com/crossplane/crossplane-tools v0.0.0-20210916125540-071de511ae8e h1:7UM
 github.com/crossplane/crossplane-tools v0.0.0-20210916125540-071de511ae8e/go.mod h1:3GzY5sP0PVePArghBh5K4fGzS/3kM0R/NAZn5s7LXqw=
 github.com/crossplane/provider-aws v0.19.0 h1:pfjxtuj0ZEllzBnyA7X2MgM62EqSwKCdBwIHPsbPEBM=
 github.com/crossplane/provider-aws v0.19.0/go.mod h1:ntcIkyfgz/y+WgfBmse05S6RnCxK4cmhhtI8a7IzySs=
-github.com/crossplane/terrajet v0.3.1 h1:mFfiocxOIVWTN+ujjOCV0sd0/r7bQY5LG292HTlCAvM=
-github.com/crossplane/terrajet v0.3.1/go.mod h1:fFjGal+3iF/D3XaxuTHw0xNHO+UslVhxNkNZITDXz44=
 github.com/dave/jennifer v1.3.0/go.mod h1:fIb+770HOpJ2fmN9EPPKOqm1vMGhB+TwXKMZhrIygKg=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=
 github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpTVGlwA=
@@ -746,6 +744,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
+github.com/sergenyalcin/terrajet v0.1.1-0.20220127142712-72b516c4485a h1:IKr7Sk3ZPYelILT33PJaZP3rXD+RVTgW2wMbkeflJvU=
+github.com/sergenyalcin/terrajet v0.1.1-0.20220127142712-72b516c4485a/go.mod h1:fFjGal+3iF/D3XaxuTHw0xNHO+UslVhxNkNZITDXz44=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=

--- a/internal/controller/autoscaling/attachment/zz_controller.go
+++ b/internal/controller/autoscaling/attachment/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles Attachment managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Attachment_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Attachment_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_autoscaling_attachment"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/autoscaling/autoscalinggroup/zz_controller.go
+++ b/internal/controller/autoscaling/autoscalinggroup/zz_controller.go
@@ -40,6 +40,8 @@ import (
 // Setup adds a controller that reconciles AutoscalingGroup managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.AutoscalingGroup_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.AutoscalingGroup_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_autoscaling_group"],
@@ -49,6 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/ebsvolume/zz_controller.go
+++ b/internal/controller/ec2/ebsvolume/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles EBSVolume managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.EBSVolume_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_ebs_volume"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.EBSVolume_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ebs_volume"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/eip/zz_controller.go
+++ b/internal/controller/ec2/eip/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles EIP managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.EIP_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_eip"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.EIP_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_eip"],
@@ -49,7 +53,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/instance/zz_controller.go
+++ b/internal/controller/ec2/instance/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles Instance managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Instance_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_instance"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Instance_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_instance"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/launchtemplate/zz_controller.go
+++ b/internal/controller/ec2/launchtemplate/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles LaunchTemplate managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.LaunchTemplate_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_launch_template"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.LaunchTemplate_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_launch_template"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/networkinterface/zz_controller.go
+++ b/internal/controller/ec2/networkinterface/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles NetworkInterface managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.NetworkInterface_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_network_interface"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.NetworkInterface_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_network_interface"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/route/zz_controller.go
+++ b/internal/controller/ec2/route/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles Route managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Route_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Route_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route"],
@@ -49,7 +50,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/routetable/zz_controller.go
+++ b/internal/controller/ec2/routetable/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles RouteTable managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.RouteTable_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_route_table"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.RouteTable_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route_table"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/routetableassociation/zz_controller.go
+++ b/internal/controller/ec2/routetableassociation/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles RouteTableAssociation managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.RouteTableAssociation_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.RouteTableAssociation_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route_table_association"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/securitygroup/zz_controller.go
+++ b/internal/controller/ec2/securitygroup/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles SecurityGroup managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.SecurityGroup_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_security_group"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.SecurityGroup_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_security_group"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/securitygrouprule/zz_controller.go
+++ b/internal/controller/ec2/securitygrouprule/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles SecurityGroupRule managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.SecurityGroupRule_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.SecurityGroupRule_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_security_group_rule"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/subnet/zz_controller.go
+++ b/internal/controller/ec2/subnet/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles Subnet managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Subnet_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_subnet"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Subnet_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_subnet"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/transitgateway/zz_controller.go
+++ b/internal/controller/ec2/transitgateway/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles TransitGateway managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.TransitGateway_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_ec2_transit_gateway"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.TransitGateway_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ec2_transit_gateway"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/transitgatewayroute/zz_controller.go
+++ b/internal/controller/ec2/transitgatewayroute/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles TransitGatewayRoute managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.TransitGatewayRoute_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.TransitGatewayRoute_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ec2_transit_gateway_route"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/transitgatewayroutetable/zz_controller.go
+++ b/internal/controller/ec2/transitgatewayroutetable/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles TransitGatewayRouteTable managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.TransitGatewayRouteTable_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_ec2_transit_gateway_route_table"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.TransitGatewayRouteTable_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ec2_transit_gateway_route_table"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/transitgatewayroutetableassociation/zz_controller.go
+++ b/internal/controller/ec2/transitgatewayroutetableassociation/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles TransitGatewayRouteTableAssociation managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.TransitGatewayRouteTableAssociation_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.TransitGatewayRouteTableAssociation_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ec2_transit_gateway_route_table_association"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/transitgatewayroutetablepropagation/zz_controller.go
+++ b/internal/controller/ec2/transitgatewayroutetablepropagation/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles TransitGatewayRouteTablePropagation managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.TransitGatewayRouteTablePropagation_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.TransitGatewayRouteTablePropagation_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ec2_transit_gateway_route_table_propagation"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/transitgatewayvpcattachment/zz_controller.go
+++ b/internal/controller/ec2/transitgatewayvpcattachment/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles TransitGatewayVPCAttachment managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.TransitGatewayVPCAttachment_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_ec2_transit_gateway_vpc_attachment"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.TransitGatewayVPCAttachment_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ec2_transit_gateway_vpc_attachment"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/transitgatewayvpcattachmentaccepter/zz_controller.go
+++ b/internal/controller/ec2/transitgatewayvpcattachmentaccepter/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles TransitGatewayVPCAttachmentAccepter managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.TransitGatewayVPCAttachmentAccepter_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_ec2_transit_gateway_vpc_attachment_accepter"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.TransitGatewayVPCAttachmentAccepter_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ec2_transit_gateway_vpc_attachment_accepter"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/vpc/zz_controller.go
+++ b/internal/controller/ec2/vpc/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles VPC managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.VPC_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_vpc"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.VPC_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_vpc"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/vpcendpoint/zz_controller.go
+++ b/internal/controller/ec2/vpcendpoint/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles VPCEndpoint managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.VPCEndpoint_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_vpc_endpoint"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.VPCEndpoint_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_vpc_endpoint"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/vpcipv4cidrblockassociation/zz_controller.go
+++ b/internal/controller/ec2/vpcipv4cidrblockassociation/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles VPCIPv4CidrBlockAssociation managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.VPCIPv4CidrBlockAssociation_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.VPCIPv4CidrBlockAssociation_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_vpc_ipv4_cidr_block_association"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ec2/vpcpeeringconnection/zz_controller.go
+++ b/internal/controller/ec2/vpcpeeringconnection/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles VPCPeeringConnection managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.VPCPeeringConnection_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_vpc_peering_connection"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.VPCPeeringConnection_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_vpc_peering_connection"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ecr/repository/zz_controller.go
+++ b/internal/controller/ecr/repository/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles Repository managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Repository_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_ecr_repository"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Repository_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ecr_repository"],
@@ -49,6 +54,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ecrpublic/repository/zz_controller.go
+++ b/internal/controller/ecrpublic/repository/zz_controller.go
@@ -40,6 +40,8 @@ import (
 // Setup adds a controller that reconciles Repository managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Repository_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Repository_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ecrpublic_repository"],
@@ -49,6 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ecs/capacityprovider/zz_controller.go
+++ b/internal/controller/ecs/capacityprovider/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles CapacityProvider managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.CapacityProvider_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_ecs_capacity_provider"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.CapacityProvider_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ecs_capacity_provider"])),
@@ -47,6 +52,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ecs/cluster/zz_controller.go
+++ b/internal/controller/ecs/cluster/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles Cluster managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Cluster_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_ecs_cluster"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Cluster_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ecs_cluster"],
@@ -49,6 +54,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ecs/service/zz_controller.go
+++ b/internal/controller/ecs/service/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles Service managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Service_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_ecs_service"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Service_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ecs_service"],
@@ -49,6 +54,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/ecs/taskdefinition/zz_controller.go
+++ b/internal/controller/ecs/taskdefinition/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles TaskDefinition managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.TaskDefinition_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_ecs_task_definition"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.TaskDefinition_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_ecs_task_definition"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/eks/addon/zz_controller.go
+++ b/internal/controller/eks/addon/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles Addon managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Addon_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_eks_addon"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Addon_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_eks_addon"])),
@@ -47,6 +52,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/eks/cluster/zz_controller.go
+++ b/internal/controller/eks/cluster/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles Cluster managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Cluster_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_eks_cluster"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Cluster_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_eks_cluster"],
@@ -49,6 +54,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/eks/fargateprofile/zz_controller.go
+++ b/internal/controller/eks/fargateprofile/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles FargateProfile managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.FargateProfile_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_eks_fargate_profile"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.FargateProfile_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_eks_fargate_profile"])),
@@ -47,6 +52,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/eks/identityproviderconfig/zz_controller.go
+++ b/internal/controller/eks/identityproviderconfig/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles IdentityProviderConfig managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.IdentityProviderConfig_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_eks_identity_provider_config"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.IdentityProviderConfig_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_eks_identity_provider_config"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/eks/nodegroup/zz_controller.go
+++ b/internal/controller/eks/nodegroup/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles NodeGroup managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.NodeGroup_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_eks_node_group"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.NodeGroup_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_eks_node_group"],
@@ -49,6 +54,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/elasticache/cluster/zz_controller.go
+++ b/internal/controller/elasticache/cluster/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles Cluster managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Cluster_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_elasticache_cluster"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Cluster_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_elasticache_cluster"],
@@ -49,6 +54,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/elasticache/parametergroup/zz_controller.go
+++ b/internal/controller/elasticache/parametergroup/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles ParameterGroup managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.ParameterGroup_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_elasticache_parameter_group"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.ParameterGroup_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_elasticache_parameter_group"])),
@@ -47,6 +52,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/elasticache/replicationgroup/zz_controller.go
+++ b/internal/controller/elasticache/replicationgroup/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles ReplicationGroup managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.ReplicationGroup_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_elasticache_replication_group"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.ReplicationGroup_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_elasticache_replication_group"])),
@@ -47,6 +52,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/elasticache/user/zz_controller.go
+++ b/internal/controller/elasticache/user/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles User managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.User_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_elasticache_user"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.User_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_elasticache_user"])),
@@ -47,6 +52,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/elasticache/usergroup/zz_controller.go
+++ b/internal/controller/elasticache/usergroup/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles UserGroup managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.UserGroup_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_elasticache_user_group"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.UserGroup_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_elasticache_user_group"])),
@@ -47,6 +52,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/elbv2/lb/zz_controller.go
+++ b/internal/controller/elbv2/lb/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles LB managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.LB_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_lb"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.LB_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_lb"],
@@ -49,7 +53,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/elbv2/lblistener/zz_controller.go
+++ b/internal/controller/elbv2/lblistener/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles LBListener managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.LBListener_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_lb_listener"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.LBListener_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_lb_listener"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/elbv2/lbtargetgroup/zz_controller.go
+++ b/internal/controller/elbv2/lbtargetgroup/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles LBTargetGroup managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.LBTargetGroup_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_lb_target_group"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.LBTargetGroup_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_lb_target_group"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/elbv2/lbtargetgroupattachment/zz_controller.go
+++ b/internal/controller/elbv2/lbtargetgroupattachment/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles LBTargetGroupAttachment managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.LBTargetGroupAttachment_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.LBTargetGroupAttachment_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_lb_target_group_attachment"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/iam/accesskey/zz_controller.go
+++ b/internal/controller/iam/accesskey/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles AccessKey managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.AccessKey_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.AccessKey_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_iam_access_key"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/iam/group/zz_controller.go
+++ b/internal/controller/iam/group/zz_controller.go
@@ -40,6 +40,8 @@ import (
 // Setup adds a controller that reconciles Group managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Group_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Group_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_iam_group"])),
@@ -47,6 +49,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/iam/grouppolicyattachment/zz_controller.go
+++ b/internal/controller/iam/grouppolicyattachment/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles GroupPolicyAttachment managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.GroupPolicyAttachment_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.GroupPolicyAttachment_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_iam_group_policy_attachment"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/iam/instanceprofile/zz_controller.go
+++ b/internal/controller/iam/instanceprofile/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles InstanceProfile managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.InstanceProfile_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_iam_instance_profile"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.InstanceProfile_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_iam_instance_profile"])),
@@ -47,6 +52,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/iam/policy/zz_controller.go
+++ b/internal/controller/iam/policy/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles Policy managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Policy_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_iam_policy"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Policy_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_iam_policy"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/iam/role/zz_controller.go
+++ b/internal/controller/iam/role/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles Role managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Role_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_iam_role"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Role_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_iam_role"])),
@@ -47,6 +52,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/iam/rolepolicyattachment/zz_controller.go
+++ b/internal/controller/iam/rolepolicyattachment/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles RolePolicyAttachment managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.RolePolicyAttachment_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.RolePolicyAttachment_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_iam_role_policy_attachment"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/iam/usergroupmembership/zz_controller.go
+++ b/internal/controller/iam/usergroupmembership/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles UserGroupMembership managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.UserGroupMembership_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.UserGroupMembership_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_iam_user_group_membership"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/iam/userpolicyattachment/zz_controller.go
+++ b/internal/controller/iam/userpolicyattachment/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles UserPolicyAttachment managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.UserPolicyAttachment_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.UserPolicyAttachment_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_iam_user_policy_attachment"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/kms/key/zz_controller.go
+++ b/internal/controller/kms/key/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles Key managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Key_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_kms_key"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Key_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_kms_key"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/rds/cluster/zz_controller.go
+++ b/internal/controller/rds/cluster/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles Cluster managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Cluster_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_rds_cluster"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Cluster_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_rds_cluster"],
@@ -49,6 +54,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/rds/instance/zz_controller.go
+++ b/internal/controller/rds/instance/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles Instance managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Instance_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_db_instance"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Instance_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_db_instance"],
@@ -49,6 +54,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/rds/parametergroup/zz_controller.go
+++ b/internal/controller/rds/parametergroup/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles ParameterGroup managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.ParameterGroup_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_db_parameter_group"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.ParameterGroup_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_db_parameter_group"])),
@@ -47,6 +52,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53/delegationset/zz_controller.go
+++ b/internal/controller/route53/delegationset/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles DelegationSet managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.DelegationSet_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.DelegationSet_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_delegation_set"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53/healthcheck/zz_controller.go
+++ b/internal/controller/route53/healthcheck/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles HealthCheck managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.HealthCheck_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_route53_health_check"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.HealthCheck_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_health_check"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53/hostedzonednssec/zz_controller.go
+++ b/internal/controller/route53/hostedzonednssec/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles HostedZoneDNSSEC managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.HostedZoneDNSSEC_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.HostedZoneDNSSEC_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_hosted_zone_dnssec"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53/keysigningkey/zz_controller.go
+++ b/internal/controller/route53/keysigningkey/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles KeySigningKey managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.KeySigningKey_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.KeySigningKey_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_key_signing_key"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53/querylog/zz_controller.go
+++ b/internal/controller/route53/querylog/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles QueryLog managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.QueryLog_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.QueryLog_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_query_log"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53/record/zz_controller.go
+++ b/internal/controller/route53/record/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles Record managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Record_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Record_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_record"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53/vpcassociationauthorization/zz_controller.go
+++ b/internal/controller/route53/vpcassociationauthorization/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles VPCAssociationAuthorization managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.VPCAssociationAuthorization_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.VPCAssociationAuthorization_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_vpc_association_authorization"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53/zone/zz_controller.go
+++ b/internal/controller/route53/zone/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles Zone managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Zone_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_route53_zone"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Zone_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_zone"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53/zoneassociation/zz_controller.go
+++ b/internal/controller/route53/zoneassociation/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles ZoneAssociation managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.ZoneAssociation_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.ZoneAssociation_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_zone_association"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53resolver/dnssecconfig/zz_controller.go
+++ b/internal/controller/route53resolver/dnssecconfig/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles DNSSECConfig managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.DNSSECConfig_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.DNSSECConfig_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_resolver_dnssec_config"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53resolver/firewallconfig/zz_controller.go
+++ b/internal/controller/route53resolver/firewallconfig/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles FirewallConfig managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.FirewallConfig_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.FirewallConfig_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_resolver_firewall_config"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53resolver/firewalldomainlist/zz_controller.go
+++ b/internal/controller/route53resolver/firewalldomainlist/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles FirewallDomainList managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.FirewallDomainList_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_route53_resolver_firewall_domain_list"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.FirewallDomainList_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_resolver_firewall_domain_list"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53resolver/firewallrule/zz_controller.go
+++ b/internal/controller/route53resolver/firewallrule/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles FirewallRule managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.FirewallRule_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.FirewallRule_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_resolver_firewall_rule"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53resolver/firewallrulegroup/zz_controller.go
+++ b/internal/controller/route53resolver/firewallrulegroup/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles FirewallRuleGroup managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.FirewallRuleGroup_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_route53_resolver_firewall_rule_group"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.FirewallRuleGroup_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_resolver_firewall_rule_group"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53resolver/firewallrulegroupassociation/zz_controller.go
+++ b/internal/controller/route53resolver/firewallrulegroupassociation/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles FirewallRuleGroupAssociation managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.FirewallRuleGroupAssociation_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_route53_resolver_firewall_rule_group_association"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.FirewallRuleGroupAssociation_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_resolver_firewall_rule_group_association"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53resolver/querylogconfig/zz_controller.go
+++ b/internal/controller/route53resolver/querylogconfig/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles QueryLogConfig managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.QueryLogConfig_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_route53_resolver_query_log_config"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.QueryLogConfig_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_resolver_query_log_config"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53resolver/querylogconfigassociation/zz_controller.go
+++ b/internal/controller/route53resolver/querylogconfigassociation/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles QueryLogConfigAssociation managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.QueryLogConfigAssociation_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.QueryLogConfigAssociation_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_resolver_query_log_config_association"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53resolver/rule/zz_controller.go
+++ b/internal/controller/route53resolver/rule/zz_controller.go
@@ -40,6 +40,10 @@ import (
 // Setup adds a controller that reconciles Rule managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.Rule_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_route53_resolver_rule"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.Rule_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_resolver_rule"])),
@@ -47,7 +51,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/route53resolver/ruleassociation/zz_controller.go
+++ b/internal/controller/route53resolver/ruleassociation/zz_controller.go
@@ -40,6 +40,7 @@ import (
 // Setup adds a controller that reconciles RuleAssociation managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha1.RuleAssociation_GroupVersionKind.String())
+	var initializers managed.InitializerChain
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha1.RuleAssociation_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_route53_resolver_rule_association"])),
@@ -47,7 +48,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		managed.WithInitializers(),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/internal/controller/s3/bucket/zz_controller.go
+++ b/internal/controller/s3/bucket/zz_controller.go
@@ -40,6 +40,11 @@ import (
 // Setup adds a controller that reconciles Bucket managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName(v1alpha2.Bucket_GroupVersionKind.String())
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["aws_s3_bucket"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind(v1alpha2.Bucket_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["aws_s3_bucket"])),
@@ -47,6 +52,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		managed.WithInitializers(initializers),
 	)
 
 	return ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
### Description of your changes

Fixes #136 

This PR adds tagging convention for provider-aws.

This PR depends on https://github.com/crossplane/terrajet/pull/198

Until merge the dependent PR, a temporary replace command was added to go.mod.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Some example manifests were applied. Then tags of MRs and external resources were checked.

[contribution process]: https://git.io/fj2m9
