### PR TITLE
Fix "vpcIdRef" field in EC2 and Route53 subresources

### DIFF
--- a/apis/ec2/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/ec2/v1alpha2/zz_generated.deepcopy.go
@@ -4061,13 +4061,13 @@ func (in *RouteTableParameters) DeepCopyInto(out *RouteTableParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.VPCIDRef != nil {
-		in, out := &in.VPCIDRef, &out.VPCIDRef
+	if in.VpcIdRef != nil {
+		in, out := &in.VpcIdRef, &out.VpcIdRef
 		*out = new(v1.Reference)
 		**out = **in
 	}
-	if in.VPCIDSelector != nil {
-		in, out := &in.VPCIDSelector, &out.VPCIDSelector
+	if in.VpcIdSelector != nil {
+		in, out := &in.VpcIdSelector, &out.VpcIdSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}
@@ -4418,13 +4418,13 @@ func (in *SecurityGroupParameters) DeepCopyInto(out *SecurityGroupParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.VPCIDRef != nil {
-		in, out := &in.VPCIDRef, &out.VPCIDRef
+	if in.VpcIdRef != nil {
+		in, out := &in.VpcIdRef, &out.VpcIdRef
 		*out = new(v1.Reference)
 		**out = **in
 	}
-	if in.VPCIDSelector != nil {
-		in, out := &in.VPCIDSelector, &out.VPCIDSelector
+	if in.VpcIdSelector != nil {
+		in, out := &in.VpcIdSelector, &out.VpcIdSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}
@@ -4927,13 +4927,13 @@ func (in *SubnetParameters) DeepCopyInto(out *SubnetParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.VPCIDRef != nil {
-		in, out := &in.VPCIDRef, &out.VPCIDRef
+	if in.VpcIdRef != nil {
+		in, out := &in.VpcIdRef, &out.VpcIdRef
 		*out = new(v1.Reference)
 		**out = **in
 	}
-	if in.VPCIDSelector != nil {
-		in, out := &in.VPCIDSelector, &out.VPCIDSelector
+	if in.VpcIdSelector != nil {
+		in, out := &in.VpcIdSelector, &out.VpcIdSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}
@@ -6380,13 +6380,13 @@ func (in *TransitGatewayVPCAttachmentParameters) DeepCopyInto(out *TransitGatewa
 		*out = new(string)
 		**out = **in
 	}
-	if in.VPCIDRef != nil {
-		in, out := &in.VPCIDRef, &out.VPCIDRef
+	if in.VpcIdRef != nil {
+		in, out := &in.VpcIdRef, &out.VpcIdRef
 		*out = new(v1.Reference)
 		**out = **in
 	}
-	if in.VPCIDSelector != nil {
-		in, out := &in.VPCIDSelector, &out.VPCIDSelector
+	if in.VpcIdSelector != nil {
+		in, out := &in.VpcIdSelector, &out.VpcIdSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}
@@ -6727,13 +6727,13 @@ func (in *VPCEndpointParameters) DeepCopyInto(out *VPCEndpointParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.VPCIDRef != nil {
-		in, out := &in.VPCIDRef, &out.VPCIDRef
+	if in.VpcIdRef != nil {
+		in, out := &in.VpcIdRef, &out.VpcIdRef
 		*out = new(v1.Reference)
 		**out = **in
 	}
-	if in.VPCIDSelector != nil {
-		in, out := &in.VPCIDSelector, &out.VPCIDSelector
+	if in.VpcIdSelector != nil {
+		in, out := &in.VpcIdSelector, &out.VpcIdSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}
@@ -6880,13 +6880,13 @@ func (in *VPCIPv4CidrBlockAssociationParameters) DeepCopyInto(out *VPCIPv4CidrBl
 		*out = new(string)
 		**out = **in
 	}
-	if in.VPCIDRef != nil {
-		in, out := &in.VPCIDRef, &out.VPCIDRef
+	if in.VpcIdRef != nil {
+		in, out := &in.VpcIdRef, &out.VpcIdRef
 		*out = new(v1.Reference)
 		**out = **in
 	}
-	if in.VPCIDSelector != nil {
-		in, out := &in.VPCIDSelector, &out.VPCIDSelector
+	if in.VpcIdSelector != nil {
+		in, out := &in.VpcIdSelector, &out.VpcIdSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}
@@ -7289,13 +7289,13 @@ func (in *VPCPeeringConnectionParameters) DeepCopyInto(out *VPCPeeringConnection
 		*out = new(string)
 		**out = **in
 	}
-	if in.VPCIDRef != nil {
-		in, out := &in.VPCIDRef, &out.VPCIDRef
+	if in.VpcIdRef != nil {
+		in, out := &in.VpcIdRef, &out.VpcIdRef
 		*out = new(v1.Reference)
 		**out = **in
 	}
-	if in.VPCIDSelector != nil {
-		in, out := &in.VPCIDSelector, &out.VPCIDSelector
+	if in.VpcIdSelector != nil {
+		in, out := &in.VpcIdSelector, &out.VpcIdSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}

--- a/apis/ec2/v1alpha2/zz_generated.resolvers.go
+++ b/apis/ec2/v1alpha2/zz_generated.resolvers.go
@@ -610,8 +610,8 @@ func (mg *RouteTable) ResolveReferences(ctx context.Context, c client.Reader) er
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPCID),
 		Extract:      reference.ExternalName(),
-		Reference:    mg.Spec.ForProvider.VPCIDRef,
-		Selector:     mg.Spec.ForProvider.VPCIDSelector,
+		Reference:    mg.Spec.ForProvider.VpcIdRef,
+		Selector:     mg.Spec.ForProvider.VpcIdSelector,
 		To: reference.To{
 			List:    &VPCList{},
 			Managed: &VPC{},
@@ -621,7 +621,7 @@ func (mg *RouteTable) ResolveReferences(ctx context.Context, c client.Reader) er
 		return errors.Wrap(err, "mg.Spec.ForProvider.VPCID")
 	}
 	mg.Spec.ForProvider.VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.VPCIDRef = rsp.ResolvedReference
+	mg.Spec.ForProvider.VpcIdRef = rsp.ResolvedReference
 
 	return nil
 }
@@ -715,8 +715,8 @@ func (mg *SecurityGroup) ResolveReferences(ctx context.Context, c client.Reader)
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPCID),
 		Extract:      reference.ExternalName(),
-		Reference:    mg.Spec.ForProvider.VPCIDRef,
-		Selector:     mg.Spec.ForProvider.VPCIDSelector,
+		Reference:    mg.Spec.ForProvider.VpcIdRef,
+		Selector:     mg.Spec.ForProvider.VpcIdSelector,
 		To: reference.To{
 			List:    &VPCList{},
 			Managed: &VPC{},
@@ -726,7 +726,7 @@ func (mg *SecurityGroup) ResolveReferences(ctx context.Context, c client.Reader)
 		return errors.Wrap(err, "mg.Spec.ForProvider.VPCID")
 	}
 	mg.Spec.ForProvider.VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.VPCIDRef = rsp.ResolvedReference
+	mg.Spec.ForProvider.VpcIdRef = rsp.ResolvedReference
 
 	return nil
 }
@@ -767,8 +767,8 @@ func (mg *Subnet) ResolveReferences(ctx context.Context, c client.Reader) error 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPCID),
 		Extract:      reference.ExternalName(),
-		Reference:    mg.Spec.ForProvider.VPCIDRef,
-		Selector:     mg.Spec.ForProvider.VPCIDSelector,
+		Reference:    mg.Spec.ForProvider.VpcIdRef,
+		Selector:     mg.Spec.ForProvider.VpcIdSelector,
 		To: reference.To{
 			List:    &VPCList{},
 			Managed: &VPC{},
@@ -778,7 +778,7 @@ func (mg *Subnet) ResolveReferences(ctx context.Context, c client.Reader) error 
 		return errors.Wrap(err, "mg.Spec.ForProvider.VPCID")
 	}
 	mg.Spec.ForProvider.VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.VPCIDRef = rsp.ResolvedReference
+	mg.Spec.ForProvider.VpcIdRef = rsp.ResolvedReference
 
 	return nil
 }
@@ -978,8 +978,8 @@ func (mg *TransitGatewayVPCAttachment) ResolveReferences(ctx context.Context, c 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPCID),
 		Extract:      reference.ExternalName(),
-		Reference:    mg.Spec.ForProvider.VPCIDRef,
-		Selector:     mg.Spec.ForProvider.VPCIDSelector,
+		Reference:    mg.Spec.ForProvider.VpcIdRef,
+		Selector:     mg.Spec.ForProvider.VpcIdSelector,
 		To: reference.To{
 			List:    &VPCList{},
 			Managed: &VPC{},
@@ -989,7 +989,7 @@ func (mg *TransitGatewayVPCAttachment) ResolveReferences(ctx context.Context, c 
 		return errors.Wrap(err, "mg.Spec.ForProvider.VPCID")
 	}
 	mg.Spec.ForProvider.VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.VPCIDRef = rsp.ResolvedReference
+	mg.Spec.ForProvider.VpcIdRef = rsp.ResolvedReference
 
 	return nil
 }
@@ -1079,8 +1079,8 @@ func (mg *VPCEndpoint) ResolveReferences(ctx context.Context, c client.Reader) e
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPCID),
 		Extract:      reference.ExternalName(),
-		Reference:    mg.Spec.ForProvider.VPCIDRef,
-		Selector:     mg.Spec.ForProvider.VPCIDSelector,
+		Reference:    mg.Spec.ForProvider.VpcIdRef,
+		Selector:     mg.Spec.ForProvider.VpcIdSelector,
 		To: reference.To{
 			List:    &VPCList{},
 			Managed: &VPC{},
@@ -1090,7 +1090,7 @@ func (mg *VPCEndpoint) ResolveReferences(ctx context.Context, c client.Reader) e
 		return errors.Wrap(err, "mg.Spec.ForProvider.VPCID")
 	}
 	mg.Spec.ForProvider.VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.VPCIDRef = rsp.ResolvedReference
+	mg.Spec.ForProvider.VpcIdRef = rsp.ResolvedReference
 
 	return nil
 }
@@ -1105,8 +1105,8 @@ func (mg *VPCIPv4CidrBlockAssociation) ResolveReferences(ctx context.Context, c 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPCID),
 		Extract:      reference.ExternalName(),
-		Reference:    mg.Spec.ForProvider.VPCIDRef,
-		Selector:     mg.Spec.ForProvider.VPCIDSelector,
+		Reference:    mg.Spec.ForProvider.VpcIdRef,
+		Selector:     mg.Spec.ForProvider.VpcIdSelector,
 		To: reference.To{
 			List:    &VPCList{},
 			Managed: &VPC{},
@@ -1116,7 +1116,7 @@ func (mg *VPCIPv4CidrBlockAssociation) ResolveReferences(ctx context.Context, c 
 		return errors.Wrap(err, "mg.Spec.ForProvider.VPCID")
 	}
 	mg.Spec.ForProvider.VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.VPCIDRef = rsp.ResolvedReference
+	mg.Spec.ForProvider.VpcIdRef = rsp.ResolvedReference
 
 	return nil
 }
@@ -1147,8 +1147,8 @@ func (mg *VPCPeeringConnection) ResolveReferences(ctx context.Context, c client.
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPCID),
 		Extract:      reference.ExternalName(),
-		Reference:    mg.Spec.ForProvider.VPCIDRef,
-		Selector:     mg.Spec.ForProvider.VPCIDSelector,
+		Reference:    mg.Spec.ForProvider.VpcIdRef,
+		Selector:     mg.Spec.ForProvider.VpcIdSelector,
 		To: reference.To{
 			List:    &VPCList{},
 			Managed: &VPC{},
@@ -1158,7 +1158,7 @@ func (mg *VPCPeeringConnection) ResolveReferences(ctx context.Context, c client.
 		return errors.Wrap(err, "mg.Spec.ForProvider.VPCID")
 	}
 	mg.Spec.ForProvider.VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.VPCIDRef = rsp.ResolvedReference
+	mg.Spec.ForProvider.VpcIdRef = rsp.ResolvedReference
 
 	return nil
 }

--- a/apis/ec2/v1alpha2/zz_routetable_types.go
+++ b/apis/ec2/v1alpha2/zz_routetable_types.go
@@ -52,14 +52,16 @@ type RouteTableParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// +crossplane:generate:reference:type=VPC
+	// +crossplane:generate:reference:refFieldName=VpcIdRef
+	// +crossplane:generate:reference:selectorFieldName=VpcIdSelector
 	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcId,omitempty" tf:"vpc_id,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDRef *v1.Reference `json:"vpcidRef,omitempty" tf:"-"`
+	VpcIdRef *v1.Reference `json:"vpcIdRef,omitempty" tf:"-"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDSelector *v1.Selector `json:"vpcidSelector,omitempty" tf:"-"`
+	VpcIdSelector *v1.Selector `json:"vpcIdSelector,omitempty" tf:"-"`
 }
 
 type RouteTableRouteObservation struct {

--- a/apis/ec2/v1alpha2/zz_securitygroup_types.go
+++ b/apis/ec2/v1alpha2/zz_securitygroup_types.go
@@ -148,14 +148,16 @@ type SecurityGroupParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// +crossplane:generate:reference:type=VPC
+	// +crossplane:generate:reference:refFieldName=VpcIdRef
+	// +crossplane:generate:reference:selectorFieldName=VpcIdSelector
 	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcId,omitempty" tf:"vpc_id,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDRef *v1.Reference `json:"vpcidRef,omitempty" tf:"-"`
+	VpcIdRef *v1.Reference `json:"vpcIdRef,omitempty" tf:"-"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDSelector *v1.Selector `json:"vpcidSelector,omitempty" tf:"-"`
+	VpcIdSelector *v1.Selector `json:"vpcIdSelector,omitempty" tf:"-"`
 }
 
 // SecurityGroupSpec defines the desired state of SecurityGroup

--- a/apis/ec2/v1alpha2/zz_subnet_types.go
+++ b/apis/ec2/v1alpha2/zz_subnet_types.go
@@ -75,14 +75,16 @@ type SubnetParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// +crossplane:generate:reference:type=VPC
+	// +crossplane:generate:reference:refFieldName=VpcIdRef
+	// +crossplane:generate:reference:selectorFieldName=VpcIdSelector
 	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcId,omitempty" tf:"vpc_id,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDRef *v1.Reference `json:"vpcidRef,omitempty" tf:"-"`
+	VpcIdRef *v1.Reference `json:"vpcIdRef,omitempty" tf:"-"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDSelector *v1.Selector `json:"vpcidSelector,omitempty" tf:"-"`
+	VpcIdSelector *v1.Selector `json:"vpcIdSelector,omitempty" tf:"-"`
 }
 
 // SubnetSpec defines the desired state of Subnet

--- a/apis/ec2/v1alpha2/zz_transitgatewayvpcattachment_types.go
+++ b/apis/ec2/v1alpha2/zz_transitgatewayvpcattachment_types.go
@@ -81,14 +81,16 @@ type TransitGatewayVPCAttachmentParameters struct {
 	TransitGatewayIDSelector *v1.Selector `json:"transitGatewayIdSelector,omitempty" tf:"-"`
 
 	// +crossplane:generate:reference:type=VPC
+	// +crossplane:generate:reference:refFieldName=VpcIdRef
+	// +crossplane:generate:reference:selectorFieldName=VpcIdSelector
 	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcId,omitempty" tf:"vpc_id,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDRef *v1.Reference `json:"vpcidRef,omitempty" tf:"-"`
+	VpcIdRef *v1.Reference `json:"vpcIdRef,omitempty" tf:"-"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDSelector *v1.Selector `json:"vpcidSelector,omitempty" tf:"-"`
+	VpcIdSelector *v1.Selector `json:"vpcIdSelector,omitempty" tf:"-"`
 }
 
 // TransitGatewayVPCAttachmentSpec defines the desired state of TransitGatewayVPCAttachment

--- a/apis/ec2/v1alpha2/zz_vpcendpoint_types.go
+++ b/apis/ec2/v1alpha2/zz_vpcendpoint_types.go
@@ -118,14 +118,16 @@ type VPCEndpointParameters struct {
 	VPCEndpointType *string `json:"vpcEndpointType,omitempty" tf:"vpc_endpoint_type,omitempty"`
 
 	// +crossplane:generate:reference:type=VPC
+	// +crossplane:generate:reference:refFieldName=VpcIdRef
+	// +crossplane:generate:reference:selectorFieldName=VpcIdSelector
 	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcId,omitempty" tf:"vpc_id,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDRef *v1.Reference `json:"vpcidRef,omitempty" tf:"-"`
+	VpcIdRef *v1.Reference `json:"vpcIdRef,omitempty" tf:"-"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDSelector *v1.Selector `json:"vpcidSelector,omitempty" tf:"-"`
+	VpcIdSelector *v1.Selector `json:"vpcIdSelector,omitempty" tf:"-"`
 }
 
 // VPCEndpointSpec defines the desired state of VPCEndpoint

--- a/apis/ec2/v1alpha2/zz_vpcipv4cidrblockassociation_types.go
+++ b/apis/ec2/v1alpha2/zz_vpcipv4cidrblockassociation_types.go
@@ -40,14 +40,16 @@ type VPCIPv4CidrBlockAssociationParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// +crossplane:generate:reference:type=VPC
+	// +crossplane:generate:reference:refFieldName=VpcIdRef
+	// +crossplane:generate:reference:selectorFieldName=VpcIdSelector
 	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcId,omitempty" tf:"vpc_id,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDRef *v1.Reference `json:"vpcidRef,omitempty" tf:"-"`
+	VpcIdRef *v1.Reference `json:"vpcIdRef,omitempty" tf:"-"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDSelector *v1.Selector `json:"vpcidSelector,omitempty" tf:"-"`
+	VpcIdSelector *v1.Selector `json:"vpcIdSelector,omitempty" tf:"-"`
 }
 
 // VPCIPv4CidrBlockAssociationSpec defines the desired state of VPCIPv4CidrBlockAssociation

--- a/apis/ec2/v1alpha2/zz_vpcpeeringconnection_types.go
+++ b/apis/ec2/v1alpha2/zz_vpcpeeringconnection_types.go
@@ -99,14 +99,16 @@ type VPCPeeringConnectionParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// +crossplane:generate:reference:type=VPC
+	// +crossplane:generate:reference:refFieldName=VpcIdRef
+	// +crossplane:generate:reference:selectorFieldName=VpcIdSelector
 	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcId,omitempty" tf:"vpc_id,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDRef *v1.Reference `json:"vpcidRef,omitempty" tf:"-"`
+	VpcIdRef *v1.Reference `json:"vpcIdRef,omitempty" tf:"-"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDSelector *v1.Selector `json:"vpcidSelector,omitempty" tf:"-"`
+	VpcIdSelector *v1.Selector `json:"vpcIdSelector,omitempty" tf:"-"`
 }
 
 // VPCPeeringConnectionSpec defines the desired state of VPCPeeringConnection

--- a/apis/elbv2/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/elbv2/v1alpha2/zz_generated.deepcopy.go
@@ -1378,13 +1378,13 @@ func (in *LBTargetGroupParameters) DeepCopyInto(out *LBTargetGroupParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.VPCIDRef != nil {
-		in, out := &in.VPCIDRef, &out.VPCIDRef
+	if in.VpcIdRef != nil {
+		in, out := &in.VpcIdRef, &out.VpcIdRef
 		*out = new(v1.Reference)
 		**out = **in
 	}
-	if in.VPCIDSelector != nil {
-		in, out := &in.VPCIDSelector, &out.VPCIDSelector
+	if in.VpcIdSelector != nil {
+		in, out := &in.VpcIdSelector, &out.VpcIdSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}

--- a/apis/elbv2/v1alpha2/zz_generated.resolvers.go
+++ b/apis/elbv2/v1alpha2/zz_generated.resolvers.go
@@ -181,8 +181,8 @@ func (mg *LBTargetGroup) ResolveReferences(ctx context.Context, c client.Reader)
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPCID),
 		Extract:      reference.ExternalName(),
-		Reference:    mg.Spec.ForProvider.VPCIDRef,
-		Selector:     mg.Spec.ForProvider.VPCIDSelector,
+		Reference:    mg.Spec.ForProvider.VpcIdRef,
+		Selector:     mg.Spec.ForProvider.VpcIdSelector,
 		To: reference.To{
 			List:    &v1alpha21.VPCList{},
 			Managed: &v1alpha21.VPC{},
@@ -192,7 +192,7 @@ func (mg *LBTargetGroup) ResolveReferences(ctx context.Context, c client.Reader)
 		return errors.Wrap(err, "mg.Spec.ForProvider.VPCID")
 	}
 	mg.Spec.ForProvider.VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.VPCIDRef = rsp.ResolvedReference
+	mg.Spec.ForProvider.VpcIdRef = rsp.ResolvedReference
 
 	return nil
 }

--- a/apis/elbv2/v1alpha2/zz_lbtargetgroup_types.go
+++ b/apis/elbv2/v1alpha2/zz_lbtargetgroup_types.go
@@ -118,14 +118,16 @@ type LBTargetGroupParameters struct {
 	TargetType *string `json:"targetType,omitempty" tf:"target_type,omitempty"`
 
 	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.VPC
+	// +crossplane:generate:reference:refFieldName=VpcIdRef
+	// +crossplane:generate:reference:selectorFieldName=VpcIdSelector
 	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcId,omitempty" tf:"vpc_id,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDRef *v1.Reference `json:"vpcidRef,omitempty" tf:"-"`
+	VpcIdRef *v1.Reference `json:"vpcIdRef,omitempty" tf:"-"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDSelector *v1.Selector `json:"vpcidSelector,omitempty" tf:"-"`
+	VpcIdSelector *v1.Selector `json:"vpcIdSelector,omitempty" tf:"-"`
 }
 
 type LBTargetGroupStickinessObservation struct {

--- a/apis/route53/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/route53/v1alpha2/zz_generated.deepcopy.go
@@ -1459,20 +1459,20 @@ func (in *VPCAssociationAuthorizationParameters) DeepCopyInto(out *VPCAssociatio
 		*out = new(string)
 		**out = **in
 	}
-	if in.VPCIDRef != nil {
-		in, out := &in.VPCIDRef, &out.VPCIDRef
-		*out = new(v1.Reference)
-		**out = **in
-	}
-	if in.VPCIDSelector != nil {
-		in, out := &in.VPCIDSelector, &out.VPCIDSelector
-		*out = new(v1.Selector)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.VPCRegion != nil {
 		in, out := &in.VPCRegion, &out.VPCRegion
 		*out = new(string)
 		**out = **in
+	}
+	if in.VpcIdRef != nil {
+		in, out := &in.VpcIdRef, &out.VpcIdRef
+		*out = new(v1.Reference)
+		**out = **in
+	}
+	if in.VpcIdSelector != nil {
+		in, out := &in.VpcIdSelector, &out.VpcIdSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ZoneID != nil {
 		in, out := &in.ZoneID, &out.ZoneID
@@ -1558,20 +1558,20 @@ func (in *VPCParameters) DeepCopyInto(out *VPCParameters) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.VPCIDRef != nil {
-		in, out := &in.VPCIDRef, &out.VPCIDRef
-		*out = new(v1.Reference)
-		**out = **in
-	}
-	if in.VPCIDSelector != nil {
-		in, out := &in.VPCIDSelector, &out.VPCIDSelector
-		*out = new(v1.Selector)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.VPCRegion != nil {
 		in, out := &in.VPCRegion, &out.VPCRegion
 		*out = new(string)
 		**out = **in
+	}
+	if in.VpcIdRef != nil {
+		in, out := &in.VpcIdRef, &out.VpcIdRef
+		*out = new(v1.Reference)
+		**out = **in
+	}
+	if in.VpcIdSelector != nil {
+		in, out := &in.VpcIdSelector, &out.VpcIdSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 }
 
@@ -1744,20 +1744,20 @@ func (in *ZoneAssociationParameters) DeepCopyInto(out *ZoneAssociationParameters
 		*out = new(string)
 		**out = **in
 	}
-	if in.VPCIDRef != nil {
-		in, out := &in.VPCIDRef, &out.VPCIDRef
-		*out = new(v1.Reference)
-		**out = **in
-	}
-	if in.VPCIDSelector != nil {
-		in, out := &in.VPCIDSelector, &out.VPCIDSelector
-		*out = new(v1.Selector)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.VPCRegion != nil {
 		in, out := &in.VPCRegion, &out.VPCRegion
 		*out = new(string)
 		**out = **in
+	}
+	if in.VpcIdRef != nil {
+		in, out := &in.VpcIdRef, &out.VpcIdRef
+		*out = new(v1.Reference)
+		**out = **in
+	}
+	if in.VpcIdSelector != nil {
+		in, out := &in.VpcIdSelector, &out.VpcIdSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ZoneID != nil {
 		in, out := &in.ZoneID, &out.ZoneID

--- a/apis/route53/v1alpha2/zz_generated.resolvers.go
+++ b/apis/route53/v1alpha2/zz_generated.resolvers.go
@@ -146,8 +146,8 @@ func (mg *VPCAssociationAuthorization) ResolveReferences(ctx context.Context, c 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPCID),
 		Extract:      reference.ExternalName(),
-		Reference:    mg.Spec.ForProvider.VPCIDRef,
-		Selector:     mg.Spec.ForProvider.VPCIDSelector,
+		Reference:    mg.Spec.ForProvider.VpcIdRef,
+		Selector:     mg.Spec.ForProvider.VpcIdSelector,
 		To: reference.To{
 			List:    &v1alpha21.VPCList{},
 			Managed: &v1alpha21.VPC{},
@@ -157,7 +157,7 @@ func (mg *VPCAssociationAuthorization) ResolveReferences(ctx context.Context, c 
 		return errors.Wrap(err, "mg.Spec.ForProvider.VPCID")
 	}
 	mg.Spec.ForProvider.VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.VPCIDRef = rsp.ResolvedReference
+	mg.Spec.ForProvider.VpcIdRef = rsp.ResolvedReference
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ZoneID),
@@ -205,8 +205,8 @@ func (mg *Zone) ResolveReferences(ctx context.Context, c client.Reader) error {
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPC[i3].VPCID),
 			Extract:      reference.ExternalName(),
-			Reference:    mg.Spec.ForProvider.VPC[i3].VPCIDRef,
-			Selector:     mg.Spec.ForProvider.VPC[i3].VPCIDSelector,
+			Reference:    mg.Spec.ForProvider.VPC[i3].VpcIdRef,
+			Selector:     mg.Spec.ForProvider.VPC[i3].VpcIdSelector,
 			To: reference.To{
 				List:    &v1alpha21.VPCList{},
 				Managed: &v1alpha21.VPC{},
@@ -216,7 +216,7 @@ func (mg *Zone) ResolveReferences(ctx context.Context, c client.Reader) error {
 			return errors.Wrap(err, "mg.Spec.ForProvider.VPC[i3].VPCID")
 		}
 		mg.Spec.ForProvider.VPC[i3].VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-		mg.Spec.ForProvider.VPC[i3].VPCIDRef = rsp.ResolvedReference
+		mg.Spec.ForProvider.VPC[i3].VpcIdRef = rsp.ResolvedReference
 
 	}
 
@@ -233,8 +233,8 @@ func (mg *ZoneAssociation) ResolveReferences(ctx context.Context, c client.Reade
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPCID),
 		Extract:      reference.ExternalName(),
-		Reference:    mg.Spec.ForProvider.VPCIDRef,
-		Selector:     mg.Spec.ForProvider.VPCIDSelector,
+		Reference:    mg.Spec.ForProvider.VpcIdRef,
+		Selector:     mg.Spec.ForProvider.VpcIdSelector,
 		To: reference.To{
 			List:    &v1alpha21.VPCList{},
 			Managed: &v1alpha21.VPC{},
@@ -244,7 +244,7 @@ func (mg *ZoneAssociation) ResolveReferences(ctx context.Context, c client.Reade
 		return errors.Wrap(err, "mg.Spec.ForProvider.VPCID")
 	}
 	mg.Spec.ForProvider.VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.VPCIDRef = rsp.ResolvedReference
+	mg.Spec.ForProvider.VpcIdRef = rsp.ResolvedReference
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.ZoneID),

--- a/apis/route53/v1alpha2/zz_vpcassociationauthorization_types.go
+++ b/apis/route53/v1alpha2/zz_vpcassociationauthorization_types.go
@@ -37,17 +37,19 @@ type VPCAssociationAuthorizationParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.VPC
+	// +crossplane:generate:reference:refFieldName=VpcIdRef
+	// +crossplane:generate:reference:selectorFieldName=VpcIdSelector
 	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcId,omitempty" tf:"vpc_id,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDRef *v1.Reference `json:"vpcidRef,omitempty" tf:"-"`
-
-	// +kubebuilder:validation:Optional
-	VPCIDSelector *v1.Selector `json:"vpcidSelector,omitempty" tf:"-"`
-
-	// +kubebuilder:validation:Optional
 	VPCRegion *string `json:"vpcRegion,omitempty" tf:"vpc_region,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	VpcIdRef *v1.Reference `json:"vpcIdRef,omitempty" tf:"-"`
+
+	// +kubebuilder:validation:Optional
+	VpcIdSelector *v1.Selector `json:"vpcIdSelector,omitempty" tf:"-"`
 
 	// +crossplane:generate:reference:type=Zone
 	// +kubebuilder:validation:Optional

--- a/apis/route53/v1alpha2/zz_zone_types.go
+++ b/apis/route53/v1alpha2/zz_zone_types.go
@@ -31,17 +31,19 @@ type VPCObservation struct {
 type VPCParameters struct {
 
 	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.VPC
+	// +crossplane:generate:reference:refFieldName=VpcIdRef
+	// +crossplane:generate:reference:selectorFieldName=VpcIdSelector
 	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcId,omitempty" tf:"vpc_id,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDRef *v1.Reference `json:"vpcidRef,omitempty" tf:"-"`
-
-	// +kubebuilder:validation:Optional
-	VPCIDSelector *v1.Selector `json:"vpcidSelector,omitempty" tf:"-"`
-
-	// +kubebuilder:validation:Optional
 	VPCRegion *string `json:"vpcRegion,omitempty" tf:"vpc_region,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	VpcIdRef *v1.Reference `json:"vpcIdRef,omitempty" tf:"-"`
+
+	// +kubebuilder:validation:Optional
+	VpcIdSelector *v1.Selector `json:"vpcIdSelector,omitempty" tf:"-"`
 }
 
 type ZoneObservation struct {

--- a/apis/route53/v1alpha2/zz_zoneassociation_types.go
+++ b/apis/route53/v1alpha2/zz_zoneassociation_types.go
@@ -39,17 +39,19 @@ type ZoneAssociationParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.VPC
+	// +crossplane:generate:reference:refFieldName=VpcIdRef
+	// +crossplane:generate:reference:selectorFieldName=VpcIdSelector
 	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcId,omitempty" tf:"vpc_id,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDRef *v1.Reference `json:"vpcidRef,omitempty" tf:"-"`
-
-	// +kubebuilder:validation:Optional
-	VPCIDSelector *v1.Selector `json:"vpcidSelector,omitempty" tf:"-"`
-
-	// +kubebuilder:validation:Optional
 	VPCRegion *string `json:"vpcRegion,omitempty" tf:"vpc_region,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	VpcIdRef *v1.Reference `json:"vpcIdRef,omitempty" tf:"-"`
+
+	// +kubebuilder:validation:Optional
+	VpcIdSelector *v1.Selector `json:"vpcIdSelector,omitempty" tf:"-"`
 
 	// +crossplane:generate:reference:type=Zone
 	// +kubebuilder:validation:Optional

--- a/apis/route53resolver/v1alpha1/zz_firewallrulegroupassociation_types.go
+++ b/apis/route53resolver/v1alpha1/zz_firewallrulegroupassociation_types.go
@@ -56,14 +56,16 @@ type FirewallRuleGroupAssociationParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.VPC
+	// +crossplane:generate:reference:refFieldName=VpcIdRef
+	// +crossplane:generate:reference:selectorFieldName=VpcIdSelector
 	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcId,omitempty" tf:"vpc_id,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDRef *v1.Reference `json:"vpcidRef,omitempty" tf:"-"`
+	VpcIdRef *v1.Reference `json:"vpcIdRef,omitempty" tf:"-"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDSelector *v1.Selector `json:"vpcidSelector,omitempty" tf:"-"`
+	VpcIdSelector *v1.Selector `json:"vpcIdSelector,omitempty" tf:"-"`
 }
 
 // FirewallRuleGroupAssociationSpec defines the desired state of FirewallRuleGroupAssociation

--- a/apis/route53resolver/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/route53resolver/v1alpha1/zz_generated.deepcopy.go
@@ -922,13 +922,13 @@ func (in *FirewallRuleGroupAssociationParameters) DeepCopyInto(out *FirewallRule
 		*out = new(string)
 		**out = **in
 	}
-	if in.VPCIDRef != nil {
-		in, out := &in.VPCIDRef, &out.VPCIDRef
+	if in.VpcIdRef != nil {
+		in, out := &in.VpcIdRef, &out.VpcIdRef
 		*out = new(v1.Reference)
 		**out = **in
 	}
-	if in.VPCIDSelector != nil {
-		in, out := &in.VPCIDSelector, &out.VPCIDSelector
+	if in.VpcIdSelector != nil {
+		in, out := &in.VpcIdSelector, &out.VpcIdSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}
@@ -1790,13 +1790,13 @@ func (in *RuleAssociationParameters) DeepCopyInto(out *RuleAssociationParameters
 		*out = new(string)
 		**out = **in
 	}
-	if in.VPCIDRef != nil {
-		in, out := &in.VPCIDRef, &out.VPCIDRef
+	if in.VpcIdRef != nil {
+		in, out := &in.VpcIdRef, &out.VpcIdRef
 		*out = new(v1.Reference)
 		**out = **in
 	}
-	if in.VPCIDSelector != nil {
-		in, out := &in.VPCIDSelector, &out.VPCIDSelector
+	if in.VpcIdSelector != nil {
+		in, out := &in.VpcIdSelector, &out.VpcIdSelector
 		*out = new(v1.Selector)
 		(*in).DeepCopyInto(*out)
 	}

--- a/apis/route53resolver/v1alpha1/zz_generated.resolvers.go
+++ b/apis/route53resolver/v1alpha1/zz_generated.resolvers.go
@@ -61,8 +61,8 @@ func (mg *FirewallRuleGroupAssociation) ResolveReferences(ctx context.Context, c
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPCID),
 		Extract:      reference.ExternalName(),
-		Reference:    mg.Spec.ForProvider.VPCIDRef,
-		Selector:     mg.Spec.ForProvider.VPCIDSelector,
+		Reference:    mg.Spec.ForProvider.VpcIdRef,
+		Selector:     mg.Spec.ForProvider.VpcIdSelector,
 		To: reference.To{
 			List:    &v1alpha2.VPCList{},
 			Managed: &v1alpha2.VPC{},
@@ -72,7 +72,7 @@ func (mg *FirewallRuleGroupAssociation) ResolveReferences(ctx context.Context, c
 		return errors.Wrap(err, "mg.Spec.ForProvider.VPCID")
 	}
 	mg.Spec.ForProvider.VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.VPCIDRef = rsp.ResolvedReference
+	mg.Spec.ForProvider.VpcIdRef = rsp.ResolvedReference
 
 	return nil
 }
@@ -87,8 +87,8 @@ func (mg *RuleAssociation) ResolveReferences(ctx context.Context, c client.Reade
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPCID),
 		Extract:      reference.ExternalName(),
-		Reference:    mg.Spec.ForProvider.VPCIDRef,
-		Selector:     mg.Spec.ForProvider.VPCIDSelector,
+		Reference:    mg.Spec.ForProvider.VpcIdRef,
+		Selector:     mg.Spec.ForProvider.VpcIdSelector,
 		To: reference.To{
 			List:    &v1alpha2.VPCList{},
 			Managed: &v1alpha2.VPC{},
@@ -98,7 +98,7 @@ func (mg *RuleAssociation) ResolveReferences(ctx context.Context, c client.Reade
 		return errors.Wrap(err, "mg.Spec.ForProvider.VPCID")
 	}
 	mg.Spec.ForProvider.VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.VPCIDRef = rsp.ResolvedReference
+	mg.Spec.ForProvider.VpcIdRef = rsp.ResolvedReference
 
 	return nil
 }

--- a/apis/route53resolver/v1alpha1/zz_ruleassociation_types.go
+++ b/apis/route53resolver/v1alpha1/zz_ruleassociation_types.go
@@ -43,14 +43,16 @@ type RuleAssociationParameters struct {
 	ResolverRuleID *string `json:"resolverRuleId" tf:"resolver_rule_id,omitempty"`
 
 	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.VPC
+	// +crossplane:generate:reference:refFieldName=VpcIdRef
+	// +crossplane:generate:reference:selectorFieldName=VpcIdSelector
 	// +kubebuilder:validation:Optional
 	VPCID *string `json:"vpcId,omitempty" tf:"vpc_id,omitempty"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDRef *v1.Reference `json:"vpcidRef,omitempty" tf:"-"`
+	VpcIdRef *v1.Reference `json:"vpcIdRef,omitempty" tf:"-"`
 
 	// +kubebuilder:validation:Optional
-	VPCIDSelector *v1.Selector `json:"vpcidSelector,omitempty" tf:"-"`
+	VpcIdSelector *v1.Selector `json:"vpcIdSelector,omitempty" tf:"-"`
 }
 
 // RuleAssociationSpec defines the desired state of RuleAssociation

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -64,13 +64,11 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_eip", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
-		r.References = config.References{
-			"instance": config.Reference{
-				Type: "Instance",
-			},
-			"network_interface": config.Reference{
-				Type: "NetworkInterface",
-			},
+		r.References["instance"] = config.Reference{
+			Type: "Instance",
+		}
+		r.References["network_interface"] = config.Reference{
+			Type: "NetworkInterface",
 		}
 		r.UseAsync = true
 	})
@@ -120,9 +118,6 @@ func Configure(p *config.Provider) {
 		}
 		r.References["transit_gateway_id"] = config.Reference{
 			Type: "TransitGateway",
-		}
-		r.References["vpc_id"] = config.Reference{
-			Type: "VPC",
 		}
 	})
 
@@ -179,9 +174,6 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_vpc_endpoint", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
-		r.References["vpc_id"] = config.Reference{
-			Type: "VPC",
-		}
 		r.References["subnet_ids"] = config.Reference{
 			Type:              "Subnet",
 			RefFieldName:      "SubnetIdRefs",
@@ -202,9 +194,6 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_subnet", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
-		r.References["vpc_id"] = config.Reference{
-			Type: "VPC",
-		}
 		r.LateInitializer = config.LateInitializer{
 			// NOTE(muvaf): Conflicts with AvailabilityZone. See the following
 			// for more details: https://github.com/crossplane/terrajet/issues/107
@@ -217,9 +206,6 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_network_interface", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
-		r.References["vpc_id"] = config.Reference{
-			Type: "VPC",
-		}
 		r.References["subnet_id"] = config.Reference{
 			Type: "Subnet",
 		}
@@ -241,9 +227,6 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_security_group", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
-		r.References["vpc_id"] = config.Reference{
-			Type: "VPC",
-		}
 		r.References["egress.security_groups"] = config.Reference{
 			Type:              "SecurityGroup",
 			RefFieldName:      "SecurityGroupRefs",
@@ -267,17 +250,11 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_vpc_ipv4_cidr_block_association", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
-		r.References["vpc_id"] = config.Reference{
-			Type: "VPC",
-		}
 	})
 
 	p.AddResourceConfigurator("aws_vpc_peering_connection", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
-		r.References["vpc_id"] = config.Reference{
-			Type: "VPC",
-		}
 		r.References["peer_vpc_id"] = config.Reference{
 			Type: "VPC",
 		}
@@ -310,10 +287,6 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_route_table", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
-		r.References["vpc_id"] = config.Reference{
-			Type: "VPC",
-		}
-
 		r.References["route.vpc_peering_connection_id"] = config.Reference{
 			Type: "VPCPeeringConnection",
 		}
@@ -342,9 +315,6 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_main_route_table_association", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
-		r.References["vpc_id"] = config.Reference{
-			Type: "VPC",
-		}
 		r.References["route_table_id"] = config.Reference{
 			Type: "RouteTable",
 		}

--- a/config/elasticloadbalancing/config.go
+++ b/config/elasticloadbalancing/config.go
@@ -69,11 +69,6 @@ func Configure(p *config.Provider) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
 		r.ExternalName.OmittedFields = append(r.ExternalName.OmittedFields, "name_prefix")
-		r.References = config.References{
-			"vpc_id": {
-				Type: "github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.VPC",
-			},
-		}
 		if s, ok := r.TerraformResource.Schema["name"]; ok {
 			s.Optional = false
 			s.ForceNew = true

--- a/config/overrides.go
+++ b/config/overrides.go
@@ -390,21 +390,25 @@ func KnownReferencers() tjconfig.ResourceOption { //nolint:gocyclo
 			switch k {
 			case "vpc_id":
 				r.References["vpc_id"] = tjconfig.Reference{
-					Type: "github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.VPC",
+					Type:              "github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.VPC",
+					RefFieldName:      "VpcIdRef",
+					SelectorFieldName: "VpcIdSelector",
 				}
 				if r.ShortGroup == "ec2" {
 					// TODO(muvaf): Angryjet should work with the full type path
 					// even when it's its own type, but it doesn't for some
 					// reason and this is a workaround.
 					r.References["vpc_id"] = tjconfig.Reference{
-						Type: "VPC",
+						Type:              "VPC",
+						RefFieldName:      "VpcIdRef",
+						SelectorFieldName: "VpcIdSelector",
 					}
 				}
 			case "subnet_ids":
 				r.References["subnet_ids"] = tjconfig.Reference{
 					Type:              "github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.Subnet",
-					RefFieldName:      "SubnetIDRefs",
-					SelectorFieldName: "SubnetIDSelector",
+					RefFieldName:      "SubnetIdRefs",
+					SelectorFieldName: "SubnetIdSelector",
 				}
 				if r.ShortGroup == "ec2" {
 					// TODO(muvaf): Angryjet should work with the full type path
@@ -412,8 +416,8 @@ func KnownReferencers() tjconfig.ResourceOption { //nolint:gocyclo
 					// reason and this is a workaround.
 					r.References["subnet_ids"] = tjconfig.Reference{
 						Type:              "Subnet",
-						RefFieldName:      "SubnetIDRefs",
-						SelectorFieldName: "SubnetIDSelector",
+						RefFieldName:      "SubnetIdRefs",
+						SelectorFieldName: "SubnetIdSelector",
 					}
 				}
 			case "subnet_id":

--- a/config/route53/config.go
+++ b/config/route53/config.go
@@ -37,44 +37,36 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_route53_hosted_zone_dnssec", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
-		r.References = config.References{
-			"hosted_zone_id": config.Reference{
-				Type: "Zone",
-			},
+		r.References["hosted_zone_id"] = config.Reference{
+			Type: "Zone",
 		}
 	})
 	p.AddResourceConfigurator("aws_route53_key_signing_key", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
-		r.References = config.References{
-			"hosted_zone_id": config.Reference{
-				Type: "Zone",
-			},
-			"key_management_service_arn": config.Reference{
-				Type:      "github.com/crossplane-contrib/provider-jet-aws/apis/kms/v1alpha2.Key",
-				Extractor: "github.com/crossplane-contrib/provider-jet-aws/apis/kms/v1alpha2.KMSKeyARN()",
-			},
+		r.References["hosted_zone_id"] = config.Reference{
+			Type: "Zone",
+		}
+		r.References["key_management_service_arn"] = config.Reference{
+			Type:      "github.com/crossplane-contrib/provider-jet-aws/apis/kms/v1alpha2.Key",
+			Extractor: "github.com/crossplane-contrib/provider-jet-aws/apis/kms/v1alpha2.KMSKeyARN()",
 		}
 	})
 	p.AddResourceConfigurator("aws_route53_query_log", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
-		r.References = config.References{
-			"hosted_zone_id": config.Reference{
-				Type: "Zone",
-			},
+		r.References["hosted_zone_id"] = config.Reference{
+			Type: "Zone",
 		}
 	})
 	p.AddResourceConfigurator("aws_route53_record", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.IdentifierFromProvider
-		r.References = config.References{
-			"zone_id": config.Reference{
-				Type: "Zone",
-			},
-			"health_check_id": config.Reference{
-				Type: "HealthCheck",
-			},
+		r.References["zone_id"] = config.Reference{
+			Type: "Zone",
+		}
+		r.References["health_check_id"] = config.Reference{
+			Type: "HealthCheck",
 		}
 	})
 	p.AddResourceConfigurator("aws_route53_vpc_association_authorization", func(r *config.Resource) {
@@ -88,13 +80,8 @@ func Configure(p *config.Provider) {
 			base["zone_id"] = words[0]
 			base["vpc_id"] = words[1]
 		}
-		r.References = config.References{
-			"zone_id": config.Reference{
-				Type: "Zone",
-			},
-			"vpc_id": config.Reference{
-				Type: "github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.VPC",
-			},
+		r.References["zone_id"] = config.Reference{
+			Type: "Zone",
 		}
 	})
 	p.AddResourceConfigurator("aws_route53_zone", func(r *config.Resource) {
@@ -105,7 +92,9 @@ func Configure(p *config.Provider) {
 				Type: "DelegationSet",
 			},
 			"vpc.vpc_id": config.Reference{
-				Type: "github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.VPC",
+				Type:              "github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.VPC",
+				RefFieldName:      "VpcIdRef",
+				SelectorFieldName: "VpcIdSelector",
 			},
 		}
 	})
@@ -124,13 +113,8 @@ func Configure(p *config.Provider) {
 				base["vpc_region"] = words[2]
 			}
 		}
-		r.References = config.References{
-			"zone_id": config.Reference{
-				Type: "Zone",
-			},
-			"vpc_id": config.Reference{
-				Type: "github.com/crossplane-contrib/provider-jet-aws/apis/ec2/v1alpha2.VPC",
-			},
+		r.References["zone_id"] = config.Reference{
+			Type: "Zone",
 		}
 	})
 }

--- a/package/crds/ec2.aws.jet.crossplane.io_routetables.yaml
+++ b/package/crds/ec2.aws.jet.crossplane.io_routetables.yaml
@@ -203,7 +203,7 @@ spec:
                     type: object
                   vpcId:
                     type: string
-                  vpcidRef:
+                  vpcIdRef:
                     description: A Reference to a named object.
                     properties:
                       name:
@@ -212,7 +212,7 @@ spec:
                     required:
                     - name
                     type: object
-                  vpcidSelector:
+                  vpcIdSelector:
                     description: A Selector selects an object.
                     properties:
                       matchControllerRef:

--- a/package/crds/ec2.aws.jet.crossplane.io_securitygroups.yaml
+++ b/package/crds/ec2.aws.jet.crossplane.io_securitygroups.yaml
@@ -206,7 +206,7 @@ spec:
                     type: object
                   vpcId:
                     type: string
-                  vpcidRef:
+                  vpcIdRef:
                     description: A Reference to a named object.
                     properties:
                       name:
@@ -215,7 +215,7 @@ spec:
                     required:
                     - name
                     type: object
-                  vpcidSelector:
+                  vpcIdSelector:
                     description: A Selector selects an object.
                     properties:
                       matchControllerRef:

--- a/package/crds/ec2.aws.jet.crossplane.io_subnets.yaml
+++ b/package/crds/ec2.aws.jet.crossplane.io_subnets.yaml
@@ -90,7 +90,7 @@ spec:
                     type: object
                   vpcId:
                     type: string
-                  vpcidRef:
+                  vpcIdRef:
                     description: A Reference to a named object.
                     properties:
                       name:
@@ -99,7 +99,7 @@ spec:
                     required:
                     - name
                     type: object
-                  vpcidSelector:
+                  vpcIdSelector:
                     description: A Selector selects an object.
                     properties:
                       matchControllerRef:

--- a/package/crds/ec2.aws.jet.crossplane.io_transitgatewayvpcattachments.yaml
+++ b/package/crds/ec2.aws.jet.crossplane.io_transitgatewayvpcattachments.yaml
@@ -138,7 +138,7 @@ spec:
                     type: object
                   vpcId:
                     type: string
-                  vpcidRef:
+                  vpcIdRef:
                     description: A Reference to a named object.
                     properties:
                       name:
@@ -147,7 +147,7 @@ spec:
                     required:
                     - name
                     type: object
-                  vpcidSelector:
+                  vpcIdSelector:
                     description: A Selector selects an object.
                     properties:
                       matchControllerRef:

--- a/package/crds/ec2.aws.jet.crossplane.io_vpcendpoints.yaml
+++ b/package/crds/ec2.aws.jet.crossplane.io_vpcendpoints.yaml
@@ -169,7 +169,7 @@ spec:
                     type: string
                   vpcId:
                     type: string
-                  vpcidRef:
+                  vpcIdRef:
                     description: A Reference to a named object.
                     properties:
                       name:
@@ -178,7 +178,7 @@ spec:
                     required:
                     - name
                     type: object
-                  vpcidSelector:
+                  vpcIdSelector:
                     description: A Selector selects an object.
                     properties:
                       matchControllerRef:

--- a/package/crds/ec2.aws.jet.crossplane.io_vpcipv4cidrblockassociations.yaml
+++ b/package/crds/ec2.aws.jet.crossplane.io_vpcipv4cidrblockassociations.yaml
@@ -72,7 +72,7 @@ spec:
                     type: string
                   vpcId:
                     type: string
-                  vpcidRef:
+                  vpcIdRef:
                     description: A Reference to a named object.
                     properties:
                       name:
@@ -81,7 +81,7 @@ spec:
                     required:
                     - name
                     type: object
-                  vpcidSelector:
+                  vpcIdSelector:
                     description: A Selector selects an object.
                     properties:
                       matchControllerRef:

--- a/package/crds/ec2.aws.jet.crossplane.io_vpcpeeringconnections.yaml
+++ b/package/crds/ec2.aws.jet.crossplane.io_vpcpeeringconnections.yaml
@@ -126,7 +126,7 @@ spec:
                     type: object
                   vpcId:
                     type: string
-                  vpcidRef:
+                  vpcIdRef:
                     description: A Reference to a named object.
                     properties:
                       name:
@@ -135,7 +135,7 @@ spec:
                     required:
                     - name
                     type: object
-                  vpcidSelector:
+                  vpcIdSelector:
                     description: A Selector selects an object.
                     properties:
                       matchControllerRef:

--- a/package/crds/elbv2.aws.jet.crossplane.io_lbtargetgroups.yaml
+++ b/package/crds/elbv2.aws.jet.crossplane.io_lbtargetgroups.yaml
@@ -140,7 +140,7 @@ spec:
                     type: string
                   vpcId:
                     type: string
-                  vpcidRef:
+                  vpcIdRef:
                     description: A Reference to a named object.
                     properties:
                       name:
@@ -149,7 +149,7 @@ spec:
                     required:
                     - name
                     type: object
-                  vpcidSelector:
+                  vpcIdSelector:
                     description: A Selector selects an object.
                     properties:
                       matchControllerRef:

--- a/package/crds/route53.aws.jet.crossplane.io_vpcassociationauthorizations.yaml
+++ b/package/crds/route53.aws.jet.crossplane.io_vpcassociationauthorizations.yaml
@@ -70,9 +70,7 @@ spec:
                     type: string
                   vpcId:
                     type: string
-                  vpcRegion:
-                    type: string
-                  vpcidRef:
+                  vpcIdRef:
                     description: A Reference to a named object.
                     properties:
                       name:
@@ -81,7 +79,7 @@ spec:
                     required:
                     - name
                     type: object
-                  vpcidSelector:
+                  vpcIdSelector:
                     description: A Selector selects an object.
                     properties:
                       matchControllerRef:
@@ -95,6 +93,8 @@ spec:
                           is selected.
                         type: object
                     type: object
+                  vpcRegion:
+                    type: string
                   zoneId:
                     type: string
                   zoneIdRef:

--- a/package/crds/route53.aws.jet.crossplane.io_zoneassociations.yaml
+++ b/package/crds/route53.aws.jet.crossplane.io_zoneassociations.yaml
@@ -68,9 +68,7 @@ spec:
                     type: string
                   vpcId:
                     type: string
-                  vpcRegion:
-                    type: string
-                  vpcidRef:
+                  vpcIdRef:
                     description: A Reference to a named object.
                     properties:
                       name:
@@ -79,7 +77,7 @@ spec:
                     required:
                     - name
                     type: object
-                  vpcidSelector:
+                  vpcIdSelector:
                     description: A Selector selects an object.
                     properties:
                       matchControllerRef:
@@ -93,6 +91,8 @@ spec:
                           is selected.
                         type: object
                     type: object
+                  vpcRegion:
+                    type: string
                   zoneId:
                     type: string
                   zoneIdRef:

--- a/package/crds/route53.aws.jet.crossplane.io_zones.yaml
+++ b/package/crds/route53.aws.jet.crossplane.io_zones.yaml
@@ -106,9 +106,7 @@ spec:
                       properties:
                         vpcId:
                           type: string
-                        vpcRegion:
-                          type: string
-                        vpcidRef:
+                        vpcIdRef:
                           description: A Reference to a named object.
                           properties:
                             name:
@@ -117,7 +115,7 @@ spec:
                           required:
                           - name
                           type: object
-                        vpcidSelector:
+                        vpcIdSelector:
                           description: A Selector selects an object.
                           properties:
                             matchControllerRef:
@@ -132,6 +130,8 @@ spec:
                                 labels is selected.
                               type: object
                           type: object
+                        vpcRegion:
+                          type: string
                       type: object
                     type: array
                 required:

--- a/package/crds/route53resolver.aws.jet.crossplane.io_firewallrulegroupassociations.yaml
+++ b/package/crds/route53resolver.aws.jet.crossplane.io_firewallrulegroupassociations.yaml
@@ -83,7 +83,7 @@ spec:
                     type: object
                   vpcId:
                     type: string
-                  vpcidRef:
+                  vpcIdRef:
                     description: A Reference to a named object.
                     properties:
                       name:
@@ -92,7 +92,7 @@ spec:
                     required:
                     - name
                     type: object
-                  vpcidSelector:
+                  vpcIdSelector:
                     description: A Selector selects an object.
                     properties:
                       matchControllerRef:

--- a/package/crds/route53resolver.aws.jet.crossplane.io_ruleassociations.yaml
+++ b/package/crds/route53resolver.aws.jet.crossplane.io_ruleassociations.yaml
@@ -72,7 +72,7 @@ spec:
                     type: string
                   vpcId:
                     type: string
-                  vpcidRef:
+                  vpcIdRef:
                     description: A Reference to a named object.
                     properties:
                       name:
@@ -81,7 +81,7 @@ spec:
                     required:
                     - name
                     type: object
-                  vpcidSelector:
+                  vpcIdSelector:
                     description: A Selector selects an object.
                     properties:
                       matchControllerRef:


### PR DESCRIPTION
Signed-off-by: ezgidemirel <ezgidemirel91@gmail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This PR replaces "vpcidRef" fields with "vpcIdRef" in EC2 and Route53 subresources. In addition to that, it refactors reference addition in some of the resources. Instead of creating a new map and assign it to references, we should append new keys during resource configurations.  
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #153 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
I applied example manifests of VPC and Subnet resources. 
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
