### PR TITLE
Add => Kubernetes v1.23.x requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ generation tools and exposes XRM-conformant managed resources for
 
 ## Getting Started
 
+This provider requires a Kubernetes cluster => v1.23.x. 
+
 Install the provider by using the following command after changing the image tag
 to the [latest release](https://github.com/crossplane-contrib/provider-jet-aws/releases):
 ```


### PR DESCRIPTION
Jet providers typically require Kubernetes => v1.23.x due to fix addressing large number of simultaneous CRD additions. Adding this requirement to provide adopters with proper guidance.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #163 

Add => Kubernetes v1.23.x requirement to README.md Getting Started section. This will help adopters/testers avoid issues with previous versions of Kubernetes that didn't support larger-scale CRD creation.

I have:

- [ x] Read and followed Crossplane's [contribution process].
- [x ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

No testing. MD file update.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
