### PR TITLE
Fix ecs.Cluster external name configuration

### DIFF
--- a/config/ecs/config.go
+++ b/config/ecs/config.go
@@ -32,6 +32,14 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_ecs_cluster", func(r *config.Resource) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.NameAsIdentifier
+		r.ExternalName.GetExternalNameFn = func(tfstate map[string]interface{}) (string, error) {
+			// expected id format: arn:aws:ecs:us-west-2:123456789123:cluster/example-cluster
+			w := strings.Split(tfstate["id"].(string), "/")
+			if len(w) != 2 {
+				return "", errors.New("terraform ID should be the ARN of the cluster")
+			}
+			return w[len(w)-1], nil
+		}
 		r.References = config.References{
 			"capacity_providers": config.Reference{
 				Type: "CapacityProvider",


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes `ecs.Cluster` external name configuration as reported in #168.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested provisioning and deleting a resource using the manifest:
```yaml
apiVersion: ecs.aws.jet.crossplane.io/v1alpha2
kind: Cluster
metadata:
  name: alper-sample-cluster
spec:
  forProvider:
    region: us-west-2
```

```
❯ k get clusters.ecs -w
NAME                   READY   SYNCED   EXTERNAL-NAME          AGE
alper-sample-cluster                    alper-sample-cluster   3s
alper-sample-cluster                    alper-sample-cluster   11s
alper-sample-cluster                    alper-sample-cluster   11s
alper-sample-cluster                    alper-sample-cluster   11s
alper-sample-cluster   False   True     alper-sample-cluster   11s
alper-sample-cluster   False   True     alper-sample-cluster   11s
alper-sample-cluster   False   True     alper-sample-cluster   30s
alper-sample-cluster   False   True     alper-sample-cluster   35s
alper-sample-cluster   True    True     alper-sample-cluster   39s
alper-sample-cluster   True    True     alper-sample-cluster   2m30s
```

Also provisioned, then orphaned and deleted a resource, and then could successfully re-import it.

[contribution process]: https://git.io/fj2m9
