### PR TITLE
Fix external name configuration for ECS Service

### DIFF
--- a/config/ecs/config.go
+++ b/config/ecs/config.go
@@ -50,10 +50,10 @@ func Configure(p *config.Provider) {
 		r.Version = common.VersionV1Alpha2
 		r.ExternalName = config.NameAsIdentifier
 		r.ExternalName.GetExternalNameFn = func(tfstate map[string]interface{}) (string, error) {
-			// cluster-name/service-name
+			// expected id format: arn:aws:ecs:us-east-2:123456789123:service/sample-cluster/sample-service
 			w := strings.Split(tfstate["id"].(string), "/")
-			if len(w) != 2 {
-				return "", errors.New("external name should have the following format: cluster-name/service-name")
+			if len(w) != 3 {
+				return "", errors.New("terraform ID should be the ARN of the service")
 			}
 			return w[len(w)-1], nil
 		}

--- a/examples/ecs/service.yaml
+++ b/examples/ecs/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: ecs.aws.jet.crossplane.io/v1alpha2
+kind: Service
+metadata:
+  name: sample-service
+spec:
+  forProvider:
+    taskDefinition: sample-task:1
+    cluster: sample-cluster
+    region: us-east-2
+    propagateTags: TASK_DEFINITION


### PR DESCRIPTION
### Description of your changes

This PR fixes ECS Service external name configuration and adds a working/tested example.

Fixes #170 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Using the (renamed) example manifest which is also added in this PR.

```bash
kubectl get -f examples/ecs/service.yaml -w
NAME                      READY   SYNCED   EXTERNAL-NAME             AGE
sample-service-by-hasan                    sample-service-by-hasan   2s
sample-service-by-hasan                    sample-service-by-hasan   35s
sample-service-by-hasan                    sample-service-by-hasan   35s
sample-service-by-hasan                    sample-service-by-hasan   35s
sample-service-by-hasan   False   True     sample-service-by-hasan   35s
sample-service-by-hasan   False   True     sample-service-by-hasan   35s
sample-service-by-hasan   False   True     sample-service-by-hasan   59s
sample-service-by-hasan   False   True     sample-service-by-hasan   63s
sample-service-by-hasan   False   True     sample-service-by-hasan   63s
sample-service-by-hasan   True    True     sample-service-by-hasan   77s
sample-service-by-hasan   True    True     sample-service-by-hasan   111s
```

[contribution process]: https://git.io/fj2m9
