### PR TITLE
Fix controller environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ GO111MODULE = on
 # ====================================================================================
 # Setup Images
 
-DOCKER_REGISTRY := crossplane
+DOCKER_REGISTRY ?= crossplane
 IMAGES = provider-jet-aws provider-jet-aws-controller
 -include build/makelib/image.mk
 

--- a/cluster/images/provider-jet-aws-controller/Dockerfile
+++ b/cluster/images/provider-jet-aws-controller/Dockerfile
@@ -36,6 +36,11 @@ RUN unzip /tmp/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip -d /usr/local/bi
 
 ADD provider /usr/local/bin/crossplane-provider
 
+# Provider controller needs these environment variable at runtime
+ENV TERRAFORM_VERSION ${TERRAFORM_VERSION}
+ENV TERRAFORM_PROVIDER_SOURCE ${TERRAFORM_PROVIDER_SOURCE}
+ENV TERRAFORM_PROVIDER_VERSION ${TERRAFORM_PROVIDER_VERSION}
+
 USER ${USER_ID}
 EXPOSE 8080
 


### PR DESCRIPTION
### Description of your changes

Currently installations from master branch fails with the following logs: 

```shell
crossplane-provider: error: required flag --terraform-version not provided, try --help
```

This PR fixes this issue by passing the required environment to the controller at runtime. It also set `DOCKER_REGISTRY` only if not set to be able to test locally built image.

As reported by a community member [on slack](https://crossplane.slack.com/archives/C02VBA32BPW/p1648320134998759?thread_ts=1648018977.771969&cid=C02VBA32BPW).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Installed the controller using a provider image from this PR.

[contribution process]: https://git.io/fj2m9
