### PR TITLE
feat(vpc-rtb-r): added examples for routetable and route + selector/ref

### DIFF
--- a/apis/ec2/v1alpha2/zz_generated.deepcopy.go
+++ b/apis/ec2/v1alpha2/zz_generated.deepcopy.go
@@ -3781,6 +3781,16 @@ func (in *RouteParameters) DeepCopyInto(out *RouteParameters) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.GatewayIDRef != nil {
+		in, out := &in.GatewayIDRef, &out.GatewayIDRef
+		*out = new(v1.Reference)
+		**out = **in
+	}
+	if in.GatewayIDSelector != nil {
+		in, out := &in.GatewayIDSelector, &out.GatewayIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.InstanceID != nil {
 		in, out := &in.InstanceID, &out.InstanceID
 		*out = new(string)

--- a/apis/ec2/v1alpha2/zz_generated.resolvers.go
+++ b/apis/ec2/v1alpha2/zz_generated.resolvers.go
@@ -456,6 +456,22 @@ func (mg *Route) ResolveReferences(ctx context.Context, c client.Reader) error {
 	var err error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.GatewayID),
+		Extract:      reference.ExternalName(),
+		Reference:    mg.Spec.ForProvider.GatewayIDRef,
+		Selector:     mg.Spec.ForProvider.GatewayIDSelector,
+		To: reference.To{
+			List:    &InternetGatewayList{},
+			Managed: &InternetGateway{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.GatewayID")
+	}
+	mg.Spec.ForProvider.GatewayID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.GatewayIDRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.InstanceID),
 		Extract:      reference.ExternalName(),
 		Reference:    mg.Spec.ForProvider.InstanceIDRef,

--- a/apis/ec2/v1alpha2/zz_route_types.go
+++ b/apis/ec2/v1alpha2/zz_route_types.go
@@ -52,8 +52,15 @@ type RouteParameters struct {
 	// +kubebuilder:validation:Optional
 	EgressOnlyGatewayID *string `json:"egressOnlyGatewayId,omitempty" tf:"egress_only_gateway_id,omitempty"`
 
+	// +crossplane:generate:reference:type=InternetGateway
 	// +kubebuilder:validation:Optional
 	GatewayID *string `json:"gatewayId,omitempty" tf:"gateway_id,omitempty"`
+
+	// +kubebuilder:validation:Optional
+	GatewayIDRef *v1.Reference `json:"gatewayIdRef,omitempty" tf:"-"`
+
+	// +kubebuilder:validation:Optional
+	GatewayIDSelector *v1.Selector `json:"gatewayIdSelector,omitempty" tf:"-"`
 
 	// +crossplane:generate:reference:type=Instance
 	// +kubebuilder:validation:Optional

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -266,6 +266,9 @@ func Configure(p *config.Provider) {
 		r.References["route_table_id"] = config.Reference{
 			Type: "RouteTable",
 		}
+		r.References["gateway_id"] = config.Reference{
+			Type: "InternetGateway",
+		}
 		r.References["instance_id"] = config.Reference{
 			Type: "Instance",
 		}

--- a/examples/ec2/route.yaml
+++ b/examples/ec2/route.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: ec2.aws.jet.crossplane.io/v1alpha2
+kind: Route
+metadata:
+  name: sample-route
+spec:
+  forProvider:
+    region: us-west-1
+    destinationCidrBlock: 0.0.0.0/0
+    gatewayIdRef:
+      name: example
+    routeTableIdRef:
+      name: sample-rtb
+  providerConfigRef:
+    name: default

--- a/examples/ec2/routetable.yaml
+++ b/examples/ec2/routetable.yaml
@@ -1,12 +1,11 @@
+---
 apiVersion: ec2.aws.jet.crossplane.io/v1alpha2
-kind: InternetGateway
+kind: RouteTable
 metadata:
-  name: example
+  name: sample-rtb
 spec:
   forProvider:
     region: us-west-1
-    tags:
-      Name: main
     vpcIdRef:
       name: sample-vpc
   providerConfigRef:

--- a/package/crds/ec2.aws.jet.crossplane.io_routes.yaml
+++ b/package/crds/ec2.aws.jet.crossplane.io_routes.yaml
@@ -75,6 +75,29 @@ spec:
                     type: string
                   gatewayId:
                     type: string
+                  gatewayIdRef:
+                    description: A Reference to a named object.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  gatewayIdSelector:
+                    description: A Selector selects an object.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                    type: object
                   instanceId:
                     type: string
                   instanceIdRef:


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
- added example for routetable without inline route
- added example for route 
- added ref/selector for gateway_id in route for internetgateway
- adopted example for internetgateway to fits vpc & providerConfig

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #184

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
NAME                                                READY   SYNCED   EXTERNAL-NAME           AGE
internetgateway.ec2.aws.jet.crossplane.io/example   True    True     igw-04366bf2a1d995e23   12m

NAME                                              READY   SYNCED   EXTERNAL-NAME           AGE
routetable.ec2.aws.jet.crossplane.io/sample-rtb   True    True     rtb-05f0d401bdd1da796   23m

NAME                                       READY   SYNCED   EXTERNAL-NAME           AGE
vpc.ec2.aws.jet.crossplane.io/sample-vpc   True    True     vpc-09dd37af4a9019ef2   44m

NAME                                           READY   SYNCED   EXTERNAL-NAME                       AGE
route.ec2.aws.jet.crossplane.io/sample-route   True    True     r-rtb-05f0d401bdd1da7961080289494   11m
```
<img width="1138" alt="image" src="https://user-images.githubusercontent.com/21083497/167294090-5e7d1641-fd93-4ad7-98ba-7e63cdaed64b.png">



<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
