### PR TITLE
fix(eks-nodegroup): fix nodegroup and add more example for provisioning

### DIFF
--- a/examples/eks/nodegroup.yaml
+++ b/examples/eks/nodegroup.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: eks.aws.jet.crossplane.io/v1alpha2
+kind: NodeGroup
+metadata:
+  name: sample-eks-ng
+spec:
+  forProvider:
+    region: us-west-1
+    clusterNameRef: 
+      name: sample-eks-cluster
+    nodeRoleArnRef:
+      name: sample-node-role
+    subnetIdRefs:
+      - name: sample-subnet1
+      - name: sample-subnet2
+    scalingConfig:
+      - minSize: 1
+        maxSize: 1
+        desiredSize: 1

--- a/examples/iam/role.yaml
+++ b/examples/iam/role.yaml
@@ -17,3 +17,23 @@ spec:
           }
         ]
       }
+---
+apiVersion: iam.aws.jet.crossplane.io/v1alpha2
+kind: Role
+metadata:
+  name: sample-node-role
+spec:
+  forProvider:
+    assumeRolePolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "ec2.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      }

--- a/examples/iam/rolepolicyattachment.yaml
+++ b/examples/iam/rolepolicyattachment.yaml
@@ -8,7 +8,7 @@ spec:
     roleRef:
       name: sample-eks-cluster
 ---
-apiVersion: iam.aws.jet.crossplane.io/v1alpha1
+apiVersion: iam.aws.jet.crossplane.io/v1alpha2
 kind: RolePolicyAttachment
 metadata:
   name: sample-vpc-resource-controller
@@ -17,3 +17,33 @@ spec:
     policyArn: arn:aws:iam::aws:policy/AmazonEKSVPCResourceController
     roleRef:
       name: sample-eks-cluster
+---
+apiVersion: iam.aws.jet.crossplane.io/v1alpha2
+kind: RolePolicyAttachment
+metadata:
+  name: sample-node-group-eks-policy
+spec:
+  forProvider:
+    policyArn: arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy
+    roleRef:
+      name: sample-node-role
+---
+apiVersion: iam.aws.jet.crossplane.io/v1alpha2
+kind: RolePolicyAttachment
+metadata:
+  name: sample-node-group-ecr-policy
+spec:
+  forProvider:
+    policyArn: arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly
+    roleRef:
+      name: sample-node-role
+---
+apiVersion: iam.aws.jet.crossplane.io/v1alpha2
+kind: RolePolicyAttachment
+metadata:
+  name: sample-node-group-cni-policy
+spec:
+  forProvider:
+    policyArn: arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy
+    roleRef:
+      name: sample-node-role


### PR DESCRIPTION
Signed-off-by: haarchri <chhaar30@googlemail.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
- add example for eks nodegroup
- fix issue for eks nodegroup with `unexpected format for ID (), expected cluster-name:node-group-name: `
- add example for eks nodegroup iam role/attchment

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #187 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```
NAME                                                   READY   SYNCED   EXTERNAL-NAME        AGE
cluster.eks.aws.jet.crossplane.io/sample-eks-cluster   True    True     sample-eks-cluster   39m

NAME                                                READY   SYNCED   EXTERNAL-NAME   AGE
nodegroup.eks.aws.jet.crossplane.io/sample-eks-ng   True   True     sample-eks-ng   28m

NAME                                                READY   SYNCED   EXTERNAL-NAME        AGE
role.iam.aws.jet.crossplane.io/sample-eks-cluster   True    True     sample-eks-cluster   7h34m
role.iam.aws.jet.crossplane.io/sample-node-role     True    True     sample-node-role     31m

NAME                                                                            READY   SYNCED   EXTERNAL-NAME                                   AGE
rolepolicyattachment.iam.aws.jet.crossplane.io/sample-cluster-policy            True    True     sample-eks-cluster-20220508185853757700000001   41m
rolepolicyattachment.iam.aws.jet.crossplane.io/sample-node-group-cni-policy     True    True     sample-node-role-20220508193956943000000001     31m
rolepolicyattachment.iam.aws.jet.crossplane.io/sample-node-group-ecr-policy     True    True     sample-node-role-20220508190934091000000001     31m
rolepolicyattachment.iam.aws.jet.crossplane.io/sample-node-group-eks-policy     True    True     sample-node-role-20220508190918097700000001     31m
rolepolicyattachment.iam.aws.jet.crossplane.io/sample-vpc-resource-controller   True    True     sample-eks-cluster-20220508194005305700000001   40m
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
