### PR TITLE
fix: use current release version in getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ generation tools and exposes XRM-conformant managed resources for
 Install the provider by using the following command after changing the image tag
 to the [latest release](https://github.com/crossplane-contrib/provider-jet-aws/releases):
 ```
-kubectl crossplane install provider crossplane/provider-jet-aws:v0.2.1
+kubectl crossplane install provider crossplane/provider-jet-aws:v0.4.2
 ```
 
 You can see the API reference [here](https://doc.crds.dev/github.com/crossplane-contrib/provider-jet-aws).


### PR DESCRIPTION
The old version (v0.2.1) is not in docker hub and leads to problems when just copying and pasting.

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
