### PR TITLE
Add associate_public_ip_address, vpc_security_group_ids, ipv6_address…

### DIFF
--- a/apis/ec2/v1alpha2/zz_generated_terraformed.go
+++ b/apis/ec2/v1alpha2/zz_generated_terraformed.go
@@ -755,10 +755,14 @@ func (tr *Instance) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("AssociatePublicIPAddress"))
+	opts = append(opts, resource.WithNameFilter("IPv6AddressCount"))
+	opts = append(opts, resource.WithNameFilter("IPv6Addresses"))
 	opts = append(opts, resource.WithNameFilter("NetworkInterface"))
 	opts = append(opts, resource.WithNameFilter("PrivateIP"))
 	opts = append(opts, resource.WithNameFilter("SourceDestCheck"))
 	opts = append(opts, resource.WithNameFilter("SubnetID"))
+	opts = append(opts, resource.WithNameFilter("VPCSecurityGroupIds"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -58,6 +58,10 @@ func Configure(p *config.Provider) {
 				"network_interface",
 				"private_ip",
 				"source_dest_check",
+				"associate_public_ip_address",
+				"vpc_security_group_ids",
+				"ipv6_addresses",
+				"ipv6_address_count",
 			},
 		}
 	})


### PR DESCRIPTION
…es, ipv6_address_count to aws_instance ignored fields for proper work with attached network interface.

Signed-off-by: Oleg Senin <olegsenin@yandex-team.ru>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Fix conflicts, when instance creates with network interface reference.
Example:
```
apiVersion: ec2.aws.jet.crossplane.io/v1alpha2
kind: Instance
metadata:
  name: instance-a
spec:
  forProvider:
    region: us-east-2
    ami: ami-0b332808c98813fef
    instanceType: c5.xlarge
    keyName: key
    networkInterface:
    - deviceIndex: 0
      networkInterfaceIdRef:
        name: ni-a
  deletionPolicy: Delete
  providerConfigRef:
    name: default
```

I am not quite sure, that this is good idea to just ignore this fields, but it seems like there is no other solution right now.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
